### PR TITLE
feat: Profile/Administration modals, OIDC admin UI, v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3604,7 +3604,7 @@ dependencies = [
 
 [[package]]
 name = "wrazz-backend"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "wrazz-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "wrazz-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "MIT"
 authors = ["Greg Fraley <greg@fraley.dev>"]

--- a/modules/wrazz-frontend/package.json
+++ b/modules/wrazz-frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wrazz-frontend",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/modules/wrazz-frontend/src/api/admin.ts
+++ b/modules/wrazz-frontend/src/api/admin.ts
@@ -1,0 +1,52 @@
+/// Sentinel returned in the client_secret field when a secret is already stored.
+/// Send this value back unchanged to preserve the existing secret on PUT.
+export const SECRET_REDACTED = "••••";
+
+export interface OidcConfig {
+  active: boolean;
+  /** True when all four WRAZZ_OIDC_* env vars are set. Fields are read-only in this state. */
+  env_configured: boolean;
+  issuer_url: string;
+  client_id: string;
+  /** `SECRET_REDACTED` when a secret is stored; empty string when unconfigured. */
+  client_secret: string;
+  redirect_uri: string;
+  enabled: boolean;
+  suggested_redirect_uri: string | null;
+}
+
+export interface OidcStatus {
+  enabled: boolean;
+}
+
+export async function getOidcConfig(): Promise<OidcConfig> {
+  const resp = await fetch("/api/admin/oidc");
+  if (!resp.ok) throw new Error(`get oidc config failed: ${resp.status}`);
+  return resp.json();
+}
+
+export async function saveOidcConfig(
+  config: Pick<OidcConfig, "issuer_url" | "client_id" | "client_secret" | "redirect_uri" | "enabled">
+): Promise<OidcConfig> {
+  const resp = await fetch("/api/admin/oidc", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(config),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(text || `save failed: ${resp.status}`);
+  }
+  return resp.json();
+}
+
+export async function deleteOidcConfig(): Promise<void> {
+  const resp = await fetch("/api/admin/oidc", { method: "DELETE" });
+  if (!resp.ok) throw new Error(`delete oidc config failed: ${resp.status}`);
+}
+
+export async function getOidcStatus(): Promise<OidcStatus> {
+  const resp = await fetch("/api/auth/oidc/status");
+  if (!resp.ok) return { enabled: false };
+  return resp.json();
+}

--- a/modules/wrazz-frontend/src/components/Editor.tsx
+++ b/modules/wrazz-frontend/src/components/Editor.tsx
@@ -1,13 +1,18 @@
+import { useRef, useState } from "react";
 import { FileEntry } from "../api/files";
 import { CurrentUser } from "../api/auth";
 import { WrazzEditor } from "wrazz-editor";
 import { Save, Trash2 } from "../icons";
+import ProfileModal from "./modals/ProfileModal";
+import AdminModal from "./modals/AdminModal";
 
 export interface Draft {
   title: string;
   content: string;
   tags: string[];
 }
+
+type Modal = "profile" | "admin" | null;
 
 interface Props {
   file: FileEntry | null;
@@ -28,16 +33,35 @@ export default function Editor({
   user,
   onLogout,
 }: Props) {
+  const menuRef = useRef<HTMLDetailsElement>(null);
+  const [modal, setModal] = useState<Modal>(null);
+
+  function openModal(m: Modal) {
+    if (menuRef.current) menuRef.current.open = false;
+    setModal(m);
+  }
+
   return (
     <main className="editor">
       <div className="editor-header">
-        <details className="user-menu">
+        <details ref={menuRef} className="user-menu">
           <summary className="user-menu-trigger">{user.display_name}</summary>
           <div className="user-menu-dropdown">
+            <button onClick={() => openModal("profile")}>Profile</button>
+            {user.is_admin && (
+              <button onClick={() => openModal("admin")}>Administration</button>
+            )}
+            <div className="user-menu-divider" />
             <button onClick={onLogout}>Sign out</button>
           </div>
         </details>
       </div>
+      {modal === "profile" && (
+        <ProfileModal user={user} onClose={() => setModal(null)} />
+      )}
+      {modal === "admin" && (
+        <AdminModal onClose={() => setModal(null)} />
+      )}
 
       {!file || !draft ? (
         <div className="editor-empty">Select a file or create a new one.</div>

--- a/modules/wrazz-frontend/src/components/LoginPage.tsx
+++ b/modules/wrazz-frontend/src/components/LoginPage.tsx
@@ -1,5 +1,6 @@
-import { useState, FormEvent } from "react";
+import { useState, useEffect, FormEvent } from "react";
 import { login } from "../api/auth";
+import { getOidcStatus } from "../api/admin";
 import type { CurrentUser } from "../api/auth";
 
 interface Props {
@@ -11,6 +12,11 @@ export default function LoginPage({ onLogin }: Props) {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [oidcEnabled, setOidcEnabled] = useState(false);
+
+  useEffect(() => {
+    getOidcStatus().then((s) => setOidcEnabled(s.enabled));
+  }, []);
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -67,6 +73,17 @@ export default function LoginPage({ onLogin }: Props) {
             {busy ? "signing in…" : "sign in"}
           </button>
         </form>
+
+        {oidcEnabled && (
+          <>
+            <div className="login-divider">
+              <span className="login-divider-label">or</span>
+            </div>
+            <a className="login-sso" href="/api/auth/oidc/redirect">
+              sign in with SSO
+            </a>
+          </>
+        )}
       </div>
     </div>
   );

--- a/modules/wrazz-frontend/src/components/modals/AdminModal.tsx
+++ b/modules/wrazz-frontend/src/components/modals/AdminModal.tsx
@@ -1,5 +1,12 @@
-import { useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import Modal from "./Modal";
+import {
+  OidcConfig,
+  SECRET_REDACTED,
+  deleteOidcConfig,
+  getOidcConfig,
+  saveOidcConfig,
+} from "../../api/admin";
 
 type AdminPage = "info" | "sso";
 
@@ -40,7 +47,7 @@ function InfoPage() {
   return (
     <div className="admin-info">
       <p className="admin-info-name">wrazz</p>
-      <p className="admin-info-version">version 0.1.1</p>
+      <p className="admin-info-version">version 0.1.2</p>
       <p className="admin-info-desc">
         Self-hosted personal journal built around plain Markdown files.
       </p>
@@ -59,13 +66,209 @@ function InfoPage() {
 }
 
 function SsoPage() {
+  const [config, setConfig] = useState<OidcConfig | null>(null);
+  const [form, setForm] = useState({
+    issuer_url: "",
+    client_id: "",
+    client_secret: "",
+    enabled: true,
+  });
+  const [showSecret, setShowSecret] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    getOidcConfig()
+      .then((c) => {
+        setConfig(c);
+        setForm({
+          issuer_url: c.issuer_url,
+          client_id: c.client_id,
+          client_secret: c.client_secret,
+          enabled: c.enabled || !c.issuer_url,
+        });
+      })
+      .catch(() => setError("Could not load SSO configuration."));
+  }, []);
+
+  function field(key: keyof typeof form, value: string) {
+    setForm((f) => ({ ...f, [key]: value }));
+    setError(null);
+    setSuccess(null);
+  }
+
+  async function handleSave(e: FormEvent) {
+    e.preventDefault();
+
+    // Redirect URI is always derived from WRAZZ_PUBLIC_URL; block if it's absent.
+    if (form.enabled && !config?.suggested_redirect_uri) {
+      setError("Set WRAZZ_PUBLIC_URL on the server to compute the redirect URI.");
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const updated = await saveOidcConfig({
+        ...form,
+        redirect_uri: config?.suggested_redirect_uri ?? "",
+      });
+      setConfig(updated);
+      setForm({
+        issuer_url: updated.issuer_url,
+        client_id: updated.client_id,
+        client_secret: updated.client_secret,
+        enabled: updated.enabled,
+      });
+      setSuccess(updated.active ? "SSO enabled." : "Configuration saved.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleDisconnect() {
+    if (!window.confirm("Remove the stored SSO configuration?")) return;
+    setBusy(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      await deleteOidcConfig();
+      const fresh = await getOidcConfig();
+      setConfig(fresh);
+      setForm({ issuer_url: "", client_id: "", client_secret: "", enabled: true });
+      setSuccess("SSO configuration removed.");
+    } catch {
+      setError("Could not remove SSO configuration.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const isConfigured = Boolean(config?.issuer_url);
+  const isReadOnly = Boolean(config?.env_configured);
+
   return (
-    <div className="admin-sso-placeholder">
-      <p className="admin-sso-placeholder-title">Single Sign-On</p>
-      <p className="admin-sso-placeholder-body">
-        OIDC configuration will be available here. For now, configure SSO via
-        the <code>WRAZZ_OIDC_*</code> environment variables.
-      </p>
-    </div>
+    <form className="sso-form" onSubmit={handleSave}>
+      <div className="sso-status">
+        <span className={`sso-status-dot${config?.active ? " sso-status-dot--active" : ""}`} />
+        <span className="sso-status-label">
+          {config === null ? "Loading…" : config.active ? "Active" : "Inactive"}
+        </span>
+      </div>
+
+      {isReadOnly && (
+        <p className="sso-env-notice">
+          Configured via <code>WRAZZ_OIDC_*</code> environment variables. Unset them to manage SSO here.
+        </p>
+      )}
+
+      <div className="sso-fields">
+        <div className="sso-field">
+          <label className="sso-label" htmlFor="sso-issuer">Issuer URL</label>
+          <input
+            id="sso-issuer"
+            className="sso-input"
+            type="url"
+            value={form.issuer_url}
+            onChange={(e) => field("issuer_url", e.target.value)}
+            placeholder="https://auth.example.com/application/o/wrazz/"
+            disabled={busy || isReadOnly}
+            required={form.enabled}
+          />
+        </div>
+
+        <div className="sso-field">
+          <label className="sso-label" htmlFor="sso-client-id">Client ID</label>
+          <input
+            id="sso-client-id"
+            className="sso-input"
+            type="text"
+            value={form.client_id}
+            onChange={(e) => field("client_id", e.target.value)}
+            disabled={busy || isReadOnly}
+            required={form.enabled}
+          />
+        </div>
+
+        <div className="sso-field">
+          <label className="sso-label" htmlFor="sso-secret">Client Secret</label>
+          <div className="sso-secret-row">
+            <input
+              id="sso-secret"
+              className="sso-input"
+              type={showSecret ? "text" : "password"}
+              value={form.client_secret}
+              onFocus={() => {
+                if (!isReadOnly && form.client_secret === SECRET_REDACTED) {
+                  field("client_secret", "");
+                }
+              }}
+              onChange={(e) => field("client_secret", e.target.value)}
+              placeholder={isConfigured ? "Leave blank to keep existing" : ""}
+              disabled={busy || isReadOnly}
+              required={form.enabled && !isConfigured}
+            />
+            <button
+              type="button"
+              className="sso-secret-toggle"
+              onClick={() => setShowSecret((s) => !s)}
+              disabled={busy}
+            >
+              {showSecret ? "Hide" : "Show"}
+            </button>
+          </div>
+        </div>
+
+        <div className="sso-field">
+          <label className="sso-label">Redirect URI</label>
+          {config?.suggested_redirect_uri ? (
+            <p className="sso-redirect-uri">{config.suggested_redirect_uri}</p>
+          ) : (
+            <p className="sso-redirect-uri sso-redirect-uri--missing">
+              Set <code>WRAZZ_PUBLIC_URL</code> on the server to compute this.
+            </p>
+          )}
+        </div>
+
+        <label className="sso-enabled-row">
+          <input
+            type="checkbox"
+            checked={form.enabled}
+            onChange={(e) => {
+              setForm((f) => ({ ...f, enabled: e.target.checked }));
+              setError(null);
+              setSuccess(null);
+            }}
+            disabled={busy || isReadOnly}
+          />
+          <span className="sso-enabled-label">Enable SSO</span>
+        </label>
+      </div>
+
+      {error && <p className="sso-message sso-message--error">{error}</p>}
+      {success && <p className="sso-message sso-message--ok">{success}</p>}
+
+      {!isReadOnly && (
+        <div className="sso-actions">
+          <button type="submit" className="sso-btn sso-btn--primary" disabled={busy || config === null}>
+            {busy ? "Saving…" : "Save"}
+          </button>
+          {isConfigured && (
+            <button
+              type="button"
+              className="sso-btn sso-btn--danger"
+              onClick={handleDisconnect}
+              disabled={busy}
+            >
+              Disconnect
+            </button>
+          )}
+        </div>
+      )}
+    </form>
   );
 }

--- a/modules/wrazz-frontend/src/components/modals/AdminModal.tsx
+++ b/modules/wrazz-frontend/src/components/modals/AdminModal.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import Modal from "./Modal";
+
+type AdminPage = "info" | "sso";
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function AdminModal({ onClose }: Props) {
+  const [page, setPage] = useState<AdminPage>("info");
+
+  return (
+    <Modal title="Administration" onClose={onClose} wide>
+      <div className="admin-modal-inner">
+        <nav className="admin-nav">
+          <button
+            className={`admin-nav-item${page === "info" ? " active" : ""}`}
+            onClick={() => setPage("info")}
+          >
+            Info
+          </button>
+          <button
+            className={`admin-nav-item${page === "sso" ? " active" : ""}`}
+            onClick={() => setPage("sso")}
+          >
+            SSO
+          </button>
+        </nav>
+        <div className="admin-section">
+          {page === "info" && <InfoPage />}
+          {page === "sso" && <SsoPage />}
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function InfoPage() {
+  return (
+    <div className="admin-info">
+      <p className="admin-info-name">wrazz</p>
+      <p className="admin-info-version">version 0.1.1</p>
+      <p className="admin-info-desc">
+        Self-hosted personal journal built around plain Markdown files.
+      </p>
+      <div className="admin-info-links">
+        <a
+          className="admin-info-link"
+          href="https://github.com/gsfraley/wrazz"
+          target="_blank"
+          rel="noreferrer"
+        >
+          github.com/gsfraley/wrazz
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function SsoPage() {
+  return (
+    <div className="admin-sso-placeholder">
+      <p className="admin-sso-placeholder-title">Single Sign-On</p>
+      <p className="admin-sso-placeholder-body">
+        OIDC configuration will be available here. For now, configure SSO via
+        the <code>WRAZZ_OIDC_*</code> environment variables.
+      </p>
+    </div>
+  );
+}

--- a/modules/wrazz-frontend/src/components/modals/Modal.tsx
+++ b/modules/wrazz-frontend/src/components/modals/Modal.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+
+interface Props {
+  title: string;
+  onClose: () => void;
+  wide?: boolean;
+  children: React.ReactNode;
+}
+
+export default function Modal({ title, onClose, wide, children }: Props) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div
+        className={`modal${wide ? " modal--wide" : ""}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <span className="modal-title">{title}</span>
+          <button className="modal-close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/modules/wrazz-frontend/src/components/modals/ProfileModal.tsx
+++ b/modules/wrazz-frontend/src/components/modals/ProfileModal.tsx
@@ -1,0 +1,37 @@
+import type { CurrentUser } from "../../api/auth";
+import Modal from "./Modal";
+
+interface Props {
+  user: CurrentUser;
+  onClose: () => void;
+}
+
+export default function ProfileModal({ user, onClose }: Props) {
+  const memberSince = new Date(user.created_at).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <Modal title="Profile" onClose={onClose}>
+      <div className="modal-body">
+        <p className="profile-name">{user.display_name}</p>
+        <div className="profile-fields">
+          <div className="profile-field">
+            <span className="profile-label">Account ID</span>
+            <span className="profile-value profile-value--mono">{user.id}</span>
+          </div>
+          <div className="profile-field">
+            <span className="profile-label">Member Since</span>
+            <span className="profile-value">{memberSince}</span>
+          </div>
+          <div className="profile-field">
+            <span className="profile-label">Role</span>
+            <span className="profile-value">{user.is_admin ? "Admin" : "Member"}</span>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/modules/wrazz-frontend/src/index.css
+++ b/modules/wrazz-frontend/src/index.css
@@ -597,26 +597,204 @@ body {
   text-decoration: underline;
 }
 
-.admin-sso-placeholder-title {
-  font-size: 18px;
-  font-family: Georgia, "Times New Roman", serif;
-  color: var(--ink);
-  margin-bottom: 12px;
+/* SSO configuration form */
+
+.sso-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
-.admin-sso-placeholder-body {
-  font-size: 16px;
-  font-family: Georgia, "Times New Roman", serif;
+.sso-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.sso-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--ink-muted);
+  flex-shrink: 0;
+}
+
+.sso-status-dot--active {
+  background: #5a8060;
+}
+
+.sso-status-label {
+  font-size: 12px;
+  font-family: ui-monospace, monospace;
   color: var(--ink-muted);
-  line-height: 1.6;
 }
 
-.admin-sso-placeholder-body code {
+.sso-env-notice {
+  font-size: 12px;
+  font-family: ui-monospace, monospace;
+  color: var(--ink-muted);
+  background: rgba(0, 0, 0, 0.04);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 8px 12px;
+  line-height: 1.5;
+}
+
+.sso-env-notice code {
+  font-size: 11px;
+  background: rgba(0, 0, 0, 0.05);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+
+.sso-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sso-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.sso-label {
+  font-size: 12px;
+  font-family: ui-monospace, monospace;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+.sso-input {
+  width: 100%;
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--paper);
+  color: var(--ink);
   font-family: ui-monospace, monospace;
   font-size: 13px;
+  outline: none;
+}
+
+.sso-input:focus {
+  border-color: var(--ink-muted);
+}
+
+.sso-input:disabled {
+  opacity: 0.5;
+}
+
+.sso-secret-row {
+  display: flex;
+  gap: 6px;
+}
+
+.sso-secret-row .sso-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.sso-secret-toggle {
+  flex-shrink: 0;
+  padding: 7px 12px;
+  font-size: 11px;
+  font-family: ui-monospace, monospace;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--ink-muted);
+  cursor: pointer;
+}
+
+.sso-secret-toggle:hover {
+  color: var(--ink);
+  border-color: var(--ink-muted);
+}
+
+.sso-redirect-uri {
+  font-size: 13px;
+  font-family: ui-monospace, monospace;
+  color: var(--ink-muted);
+  padding: 2px 0;
+}
+
+.sso-redirect-uri--missing {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 13px;
+}
+
+.sso-redirect-uri--missing code {
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
   background: rgba(0, 0, 0, 0.05);
-  padding: 1px 5px;
+  padding: 1px 4px;
   border-radius: 2px;
+}
+
+.sso-enabled-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.sso-enabled-label {
+  font-size: 13px;
+  font-family: ui-monospace, monospace;
+  color: var(--ink-muted);
+}
+
+.sso-message {
+  font-size: 12px;
+  font-family: ui-monospace, monospace;
+}
+
+.sso-message--error { color: var(--danger); }
+.sso-message--ok    { color: #5a8060; }
+
+.sso-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.sso-btn {
+  padding: 7px 16px;
+  font-size: 12px;
+  font-family: ui-monospace, monospace;
+  border-radius: 3px;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--ink-muted);
+}
+
+.sso-btn:hover {
+  color: var(--ink);
+  border-color: var(--ink-muted);
+}
+
+.sso-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.sso-btn--primary {
+  border-color: var(--border-strong);
+  color: var(--ink);
+}
+
+.sso-btn--primary:hover {
+  border-color: var(--ink-muted);
+}
+
+.sso-btn--danger:hover {
+  color: var(--danger);
+  border-color: var(--danger);
 }
 
 /* ── Buttons (generic) ────────────────────────────────────────── */
@@ -713,4 +891,48 @@ button:hover {
   width: 100%;
   padding: 7px 10px;
   font-size: 12px;
+}
+
+.login-divider {
+  position: relative;
+  text-align: center;
+  margin: 20px 0 16px;
+}
+
+.login-divider::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--border);
+}
+
+.login-divider-label {
+  position: relative;
+  background: var(--paper);
+  padding: 0 10px;
+  font-size: 11px;
+  font-family: ui-monospace, monospace;
+  color: var(--ink-muted);
+}
+
+.login-sso {
+  display: block;
+  width: 100%;
+  padding: 7px 10px;
+  text-align: center;
+  font-size: 12px;
+  font-family: ui-monospace, monospace;
+  color: var(--ink-muted);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  text-decoration: none;
+  background: transparent;
+}
+
+.login-sso:hover {
+  color: var(--ink);
+  border-color: var(--ink-muted);
 }

--- a/modules/wrazz-frontend/src/index.css
+++ b/modules/wrazz-frontend/src/index.css
@@ -1,9 +1,12 @@
 :root {
-  --paper:      #f5f0e8;
-  --ink:        #1a1a18;
-  --ink-muted:  #7a7a6e;
-  --border:     #e0d9cc;
-  --danger:     #a03030;
+  --paper:         #f5f0e8;
+  --paper-sidebar: #f1ece3;
+  --paper-topbar:  #e4dfd3;
+  --ink:           #1a1a18;
+  --ink-muted:     #7a7a6e;
+  --border:        #e0d9cc;
+  --border-strong: #c8c0b0;
+  --danger:        #a03030;
 
   /* Bridge wrazz-editor custom properties to the app theme */
   --we-ink:       var(--ink);
@@ -52,14 +55,30 @@ body {
 .editor-header {
   height: 40px;
   padding: 0 14px;
-  border-bottom: 1px solid var(--border);
+  background: var(--paper-topbar);
+  border-bottom: 1px solid var(--border-strong);
   display: flex;
   align-items: center;
   flex-shrink: 0;
 }
 
 .sidebar-header {
+  position: relative;
   justify-content: space-between;
+}
+
+/* Overlay the sidebar's --border with --border-strong in the topbar zone only.
+ * right: -1px positions the pseudo at the sidebar's outer border edge, which
+ * is 1px outside sidebar-header's content box. overflow:hidden is removed from
+ * .sidebar so this isn't clipped. */
+.sidebar-header::after {
+  content: '';
+  position: absolute;
+  right: -1px;
+  top: 0;
+  width: 1px;
+  height: 100%;
+  background: var(--border-strong);
 }
 
 .editor-header {
@@ -79,10 +98,10 @@ body {
 .sidebar {
   width: 240px;
   flex-shrink: 0;
+  background: var(--paper-sidebar);
   border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
 }
 
 .sidebar-header-actions {
@@ -317,7 +336,7 @@ body {
   font-family: ui-monospace, monospace;
   color: var(--ink-muted);
   padding: 3px 10px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-strong);
   border-radius: 3px;
   user-select: none;
 }
@@ -362,6 +381,242 @@ body {
 .user-menu-dropdown button:hover {
   color: var(--ink);
   background: rgba(0, 0, 0, 0.04);
+}
+
+.user-menu-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 3px 0;
+}
+
+/* ── Modals ───────────────────────────────────────────────────── */
+
+/*
+ * Backdrop sits ~300px above screen center.
+ * clamp(24px, 50vh - 300px, 30vh) ensures the modal never clips the top edge
+ * on small viewports and never drifts below the upper third on tall ones.
+ */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: clamp(24px, calc(50vh - 400px), 30vh);
+  padding-bottom: 24px;
+  overflow-y: auto;
+  z-index: 200;
+}
+
+.modal {
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+  width: 800px;
+  max-width: calc(100vw - 32px);
+  max-height: calc(100vh - clamp(24px, calc(50vh - 400px), 30vh) - 24px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.modal--wide {
+  width: 1200px;
+  min-height: 580px;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.modal-title {
+  font-size: 13px;
+  font-family: ui-monospace, monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--ink-muted);
+  font-size: 20px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  line-height: 1;
+}
+
+.modal-close:hover {
+  color: var(--ink);
+  background: rgba(0, 0, 0, 0.05);
+  border-color: transparent;
+}
+
+.modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 36px 30px;
+}
+
+/* Profile modal */
+
+.profile-name {
+  font-size: 30px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-weight: normal;
+  color: var(--ink);
+  margin-bottom: 28px;
+}
+
+.profile-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.profile-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.profile-label {
+  font-size: 12px;
+  font-family: ui-monospace, monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+.profile-value {
+  font-size: 16px;
+  font-family: Georgia, "Times New Roman", serif;
+  color: var(--ink);
+}
+
+.profile-value--mono {
+  font-family: ui-monospace, monospace;
+  font-size: 14px;
+  word-break: break-all;
+}
+
+/* Admin modal */
+
+.admin-modal-inner {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.admin-nav {
+  width: 160px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  padding: 10px 0;
+}
+
+.admin-nav-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  cursor: pointer;
+  font-family: ui-monospace, monospace;
+  font-size: 13px;
+  color: var(--ink-muted);
+  padding: 8px 18px;
+}
+
+.admin-nav-item:hover {
+  color: var(--ink);
+  background: rgba(0, 0, 0, 0.04);
+  border-color: transparent;
+}
+
+.admin-nav-item.active {
+  color: var(--ink);
+  background: rgba(0, 0, 0, 0.06);
+  border-color: transparent;
+}
+
+.admin-section {
+  flex: 1;
+  overflow-y: auto;
+  padding: 36px 30px;
+}
+
+.admin-info-name {
+  font-size: 28px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-weight: normal;
+  color: var(--ink);
+  margin-bottom: 6px;
+}
+
+.admin-info-version {
+  font-size: 13px;
+  font-family: ui-monospace, monospace;
+  color: var(--ink-muted);
+  margin-bottom: 22px;
+}
+
+.admin-info-desc {
+  font-size: 17px;
+  font-family: Georgia, "Times New Roman", serif;
+  color: var(--ink);
+  line-height: 1.6;
+  margin-bottom: 22px;
+}
+
+.admin-info-links {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.admin-info-link {
+  font-size: 13px;
+  font-family: ui-monospace, monospace;
+  color: var(--ink-muted);
+  text-decoration: none;
+}
+
+.admin-info-link:hover {
+  color: var(--ink);
+  text-decoration: underline;
+}
+
+.admin-sso-placeholder-title {
+  font-size: 18px;
+  font-family: Georgia, "Times New Roman", serif;
+  color: var(--ink);
+  margin-bottom: 12px;
+}
+
+.admin-sso-placeholder-body {
+  font-size: 16px;
+  font-family: Georgia, "Times New Roman", serif;
+  color: var(--ink-muted);
+  line-height: 1.6;
+}
+
+.admin-sso-placeholder-body code {
+  font-family: ui-monospace, monospace;
+  font-size: 13px;
+  background: rgba(0, 0, 0, 0.05);
+  padding: 1px 5px;
+  border-radius: 2px;
 }
 
 /* ── Buttons (generic) ────────────────────────────────────────── */

--- a/modules/wrazz-server/migrations/20260427000000_add_oidc_config.sql
+++ b/modules/wrazz-server/migrations/20260427000000_add_oidc_config.sql
@@ -1,0 +1,11 @@
+-- Singleton row for admin-configured OIDC. CHECK (id = 1) enforces at most one row.
+-- Env vars (WRAZZ_OIDC_*) take precedence over this table at startup; the admin UI
+-- writes here at runtime so OIDC can be configured without a pod restart.
+CREATE TABLE oidc_config (
+    id            INTEGER NOT NULL PRIMARY KEY CHECK (id = 1),
+    issuer_url    TEXT    NOT NULL,
+    client_id     TEXT    NOT NULL,
+    client_secret TEXT    NOT NULL,
+    redirect_uri  TEXT    NOT NULL,
+    enabled       INTEGER NOT NULL DEFAULT 1
+);

--- a/modules/wrazz-server/src/db.rs
+++ b/modules/wrazz-server/src/db.rs
@@ -205,6 +205,55 @@ pub async fn create_user_with_oidc(
     .await
 }
 
+// --- OIDC config queries ---
+
+/// The persisted OIDC provider configuration. One optional row in `oidc_config`.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct OidcConfig {
+    pub issuer_url: String,
+    pub client_id: String,
+    pub client_secret: String,
+    pub redirect_uri: String,
+    pub enabled: bool,
+}
+
+pub async fn get_oidc_config(pool: &SqlitePool) -> sqlx::Result<Option<OidcConfig>> {
+    sqlx::query_as::<_, OidcConfig>(
+        "SELECT issuer_url, client_id, client_secret, redirect_uri, enabled \
+         FROM oidc_config WHERE id = 1",
+    )
+    .fetch_optional(pool)
+    .await
+}
+
+pub async fn upsert_oidc_config(pool: &SqlitePool, config: &OidcConfig) -> sqlx::Result<()> {
+    sqlx::query(
+        "INSERT INTO oidc_config (id, issuer_url, client_id, client_secret, redirect_uri, enabled) \
+         VALUES (1, ?, ?, ?, ?, ?) \
+         ON CONFLICT(id) DO UPDATE SET \
+           issuer_url    = excluded.issuer_url, \
+           client_id     = excluded.client_id, \
+           client_secret = excluded.client_secret, \
+           redirect_uri  = excluded.redirect_uri, \
+           enabled       = excluded.enabled",
+    )
+    .bind(&config.issuer_url)
+    .bind(&config.client_id)
+    .bind(&config.client_secret)
+    .bind(&config.redirect_uri)
+    .bind(config.enabled)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn delete_oidc_config(pool: &SqlitePool) -> sqlx::Result<()> {
+    sqlx::query("DELETE FROM oidc_config WHERE id = 1")
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
 // --- Session queries ---
 
 /// Inserts a new session and returns its UUID. Expiry is stored as a Unix

--- a/modules/wrazz-server/src/main.rs
+++ b/modules/wrazz-server/src/main.rs
@@ -10,6 +10,9 @@ use argon2::{
     password_hash::{SaltString, rand_core::OsRng},
 };
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use tokio::sync::RwLock;
+
+use crate::routes::oidc::OidcProvider;
 use state::AppState;
 
 #[tokio::main]
@@ -22,10 +25,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::env::var("WRAZZ_DATA_DIR").unwrap_or_else(|_| "./data".into()).into();
     let bind = std::env::var("WRAZZ_BIND").unwrap_or_else(|_| "127.0.0.1:3001".into());
     let static_dir = std::env::var("WRAZZ_STATIC_DIR").ok();
+    let public_url = std::env::var("WRAZZ_PUBLIC_URL").ok();
     let session_hours: i64 = std::env::var("WRAZZ_SESSION_HOURS")
         .ok()
         .and_then(|v| v.parse().ok())
-        .unwrap_or(24 * 7); // default: one week
+        .unwrap_or(24 * 7);
 
     tokio::fs::create_dir_all(&data_dir).await?;
 
@@ -46,13 +50,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let store_cache = Arc::new(store_cache::StoreCache::new(&data_dir));
 
-    let oidc_provider = build_oidc_provider().await;
+    let oidc_provider = Arc::new(RwLock::new(build_oidc_provider(&pool).await));
 
     let state = AppState {
         pool: pool.clone(),
         store_cache: Arc::clone(&store_cache),
         oidc_provider,
         session_duration: chrono::Duration::hours(session_hours),
+        public_url,
     };
 
     // Background task: expire sessions and evict idle store entries hourly.
@@ -124,20 +129,49 @@ async fn maybe_bootstrap_admin(pool: &sqlx::SqlitePool) {
     }
 }
 
-/// Reads the four `WRAZZ_OIDC_*` env vars and runs provider discovery.
-async fn build_oidc_provider() -> Option<Arc<routes::oidc::OidcProvider>> {
-    let issuer_url = std::env::var("WRAZZ_OIDC_ISSUER_URL").ok()?;
-    let client_id = std::env::var("WRAZZ_OIDC_CLIENT_ID").ok()?;
-    let client_secret = std::env::var("WRAZZ_OIDC_CLIENT_SECRET").ok()?;
-    let redirect_uri = std::env::var("WRAZZ_OIDC_REDIRECT_URI").ok()?;
+/// Determines the initial OIDC provider at startup.
+///
+/// Precedence: env vars > DB config. Both sources attempt discovery; if the
+/// preferred source's discovery fails, the other source is not tried (env vars
+/// are authoritative when present; DB config is authoritative when env vars are
+/// absent).
+async fn build_oidc_provider(pool: &sqlx::SqlitePool) -> Option<Arc<OidcProvider>> {
+    // Env vars take unconditional precedence.
+    if let (Ok(issuer), Ok(client_id), Ok(secret), Ok(redirect_uri)) = (
+        std::env::var("WRAZZ_OIDC_ISSUER_URL"),
+        std::env::var("WRAZZ_OIDC_CLIENT_ID"),
+        std::env::var("WRAZZ_OIDC_CLIENT_SECRET"),
+        std::env::var("WRAZZ_OIDC_REDIRECT_URI"),
+    ) {
+        return match OidcProvider::discover(issuer, client_id, secret, redirect_uri).await {
+            Ok(p) => {
+                tracing::info!("OIDC provider configured from environment variables");
+                Some(Arc::new(p))
+            }
+            Err(e) => {
+                tracing::warn!("OIDC env var discovery failed, OIDC unavailable: {e}");
+                None
+            }
+        };
+    }
 
-    match routes::oidc::OidcProvider::discover(issuer_url, client_id, client_secret, redirect_uri).await {
-        Ok(provider) => {
-            tracing::info!("OIDC provider configured");
-            Some(Arc::new(provider))
+    // Fall back to DB config.
+    match db::get_oidc_config(pool).await {
+        Ok(Some(c)) if c.enabled => {
+            match OidcProvider::discover(c.issuer_url, c.client_id, c.client_secret, c.redirect_uri).await {
+                Ok(p) => {
+                    tracing::info!("OIDC provider configured from database");
+                    Some(Arc::new(p))
+                }
+                Err(e) => {
+                    tracing::warn!("OIDC DB config discovery failed, OIDC unavailable: {e}");
+                    None
+                }
+            }
         }
+        Ok(_) => None,
         Err(e) => {
-            tracing::warn!("OIDC discovery failed, OIDC will be unavailable: {e}");
+            tracing::warn!("failed to read OIDC config from DB: {e}");
             None
         }
     }

--- a/modules/wrazz-server/src/routes/admin.rs
+++ b/modules/wrazz-server/src/routes/admin.rs
@@ -1,0 +1,209 @@
+use std::sync::Arc;
+
+use axum::{Json, extract::State, http::StatusCode};
+use serde::{Deserialize, Serialize};
+
+use crate::db::{self, OidcConfig};
+use crate::routes::auth::AuthUser;
+use crate::routes::oidc::OidcProvider;
+use crate::state::AppState;
+
+/// Sent back for the redacted client_secret field when a config already exists.
+const SECRET_REDACT: &str = "••••";
+
+#[derive(Serialize)]
+pub struct OidcConfigResponse {
+    /// Whether the OIDC provider is currently active in memory.
+    pub active: bool,
+    /// True when all four `WRAZZ_OIDC_*` env vars are set. The config fields
+    /// reflect the env var values and the form is read-only; PUT and DELETE
+    /// return 409 while this is true.
+    pub env_configured: bool,
+    pub issuer_url: String,
+    pub client_id: String,
+    /// `"••••"` when a secret is stored; empty string when unconfigured.
+    pub client_secret: String,
+    pub redirect_uri: String,
+    pub enabled: bool,
+    /// Pre-computed redirect URI derived from `WRAZZ_PUBLIC_URL`, if set.
+    pub suggested_redirect_uri: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct OidcConfigRequest {
+    pub issuer_url: String,
+    pub client_id: String,
+    /// If this equals `"••••"`, the server keeps the existing stored secret.
+    pub client_secret: String,
+    pub redirect_uri: String,
+    pub enabled: bool,
+}
+
+/// `GET /api/admin/oidc` — return current OIDC config (secret redacted).
+///
+/// When env vars are driving the config, returns their values with
+/// `env_configured: true` so the UI can display them read-only.
+pub async fn get_oidc(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> Result<Json<OidcConfigResponse>, (StatusCode, String)> {
+    require_admin(&auth_user)?;
+
+    let active = state.oidc_provider.read().await.is_some();
+    let suggested = suggested_redirect_uri(&state);
+
+    if env_oidc_configured() {
+        return Ok(Json(OidcConfigResponse {
+            active,
+            env_configured: true,
+            issuer_url: std::env::var("WRAZZ_OIDC_ISSUER_URL").unwrap_or_default(),
+            client_id: std::env::var("WRAZZ_OIDC_CLIENT_ID").unwrap_or_default(),
+            client_secret: SECRET_REDACT.to_string(),
+            redirect_uri: std::env::var("WRAZZ_OIDC_REDIRECT_URI").unwrap_or_default(),
+            enabled: true,
+            suggested_redirect_uri: suggested,
+        }));
+    }
+
+    let config = db::get_oidc_config(&state.pool).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(match config {
+        Some(c) => OidcConfigResponse {
+            active,
+            env_configured: false,
+            issuer_url: c.issuer_url,
+            client_id: c.client_id,
+            client_secret: SECRET_REDACT.to_string(),
+            redirect_uri: c.redirect_uri,
+            enabled: c.enabled,
+            suggested_redirect_uri: suggested,
+        },
+        None => OidcConfigResponse {
+            active,
+            env_configured: false,
+            issuer_url: String::new(),
+            client_id: String::new(),
+            client_secret: String::new(),
+            redirect_uri: String::new(),
+            enabled: false,
+            suggested_redirect_uri: suggested,
+        },
+    }))
+}
+
+/// `PUT /api/admin/oidc` — save config and hot-swap the in-memory provider.
+///
+/// Returns 409 if the `WRAZZ_OIDC_*` env vars are set; unset them to manage
+/// OIDC here. Discovery is attempted before writing to the DB so bad config
+/// fails fast with 502 and the existing config is untouched.
+pub async fn put_oidc(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Json(req): Json<OidcConfigRequest>,
+) -> Result<Json<OidcConfigResponse>, (StatusCode, String)> {
+    require_admin(&auth_user)?;
+    if env_oidc_configured() {
+        return Err((StatusCode::CONFLICT,
+            "OIDC is configured via environment variables; unset WRAZZ_OIDC_* to manage it here".into()));
+    }
+
+    // Resolve the secret — sentinel means "keep what's stored".
+    let actual_secret = if req.client_secret == SECRET_REDACT {
+        db::get_oidc_config(&state.pool).await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+            .map(|c| c.client_secret)
+            .ok_or_else(|| (StatusCode::BAD_REQUEST, "no existing secret to preserve".to_string()))?
+    } else {
+        req.client_secret.clone()
+    };
+
+    // Run discovery before touching the DB so we fail fast on bad config.
+    let new_provider: Option<Arc<OidcProvider>> = if req.enabled {
+        match OidcProvider::discover(
+            req.issuer_url.clone(),
+            req.client_id.clone(),
+            actual_secret.clone(),
+            req.redirect_uri.clone(),
+        ).await {
+            Ok(p) => Some(Arc::new(p)),
+            Err(e) => return Err((StatusCode::BAD_GATEWAY, format!("OIDC discovery failed: {e}"))),
+        }
+    } else {
+        None
+    };
+
+    // Persist.
+    db::upsert_oidc_config(&state.pool, &OidcConfig {
+        issuer_url: req.issuer_url.clone(),
+        client_id: req.client_id.clone(),
+        client_secret: actual_secret,
+        redirect_uri: req.redirect_uri.clone(),
+        enabled: req.enabled,
+    })
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Swap in-memory provider only when env vars aren't overriding it.
+    if !env_oidc_configured() {
+        *state.oidc_provider.write().await = new_provider;
+    }
+
+    let active = state.oidc_provider.read().await.is_some();
+
+    Ok(Json(OidcConfigResponse {
+        active,
+        env_configured: false,
+        issuer_url: req.issuer_url,
+        client_id: req.client_id,
+        client_secret: SECRET_REDACT.to_string(),
+        redirect_uri: req.redirect_uri,
+        enabled: req.enabled,
+        suggested_redirect_uri: suggested_redirect_uri(&state),
+    }))
+}
+
+/// `DELETE /api/admin/oidc` — remove DB config and disable the provider.
+///
+/// Returns 409 if the `WRAZZ_OIDC_*` env vars are set; unset them to manage
+/// OIDC here.
+pub async fn delete_oidc(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> Result<StatusCode, (StatusCode, String)> {
+    require_admin(&auth_user)?;
+    if env_oidc_configured() {
+        return Err((StatusCode::CONFLICT,
+            "OIDC is configured via environment variables; unset WRAZZ_OIDC_* to manage it here".into()));
+    }
+
+    db::delete_oidc_config(&state.pool).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    *state.oidc_provider.write().await = None;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// --- Helpers ---
+
+fn require_admin(auth_user: &AuthUser) -> Result<(), (StatusCode, String)> {
+    if auth_user.0.is_admin {
+        Ok(())
+    } else {
+        Err((StatusCode::FORBIDDEN, "admin required".into()))
+    }
+}
+
+fn suggested_redirect_uri(state: &AppState) -> Option<String> {
+    state.public_url.as_deref()
+        .map(|u| format!("{}/api/auth/oidc/callback", u.trim_end_matches('/')))
+}
+
+/// Returns true if all four `WRAZZ_OIDC_*` env vars are set, meaning the
+/// in-memory provider is driven by the environment rather than the DB.
+fn env_oidc_configured() -> bool {
+    ["WRAZZ_OIDC_ISSUER_URL", "WRAZZ_OIDC_CLIENT_ID", "WRAZZ_OIDC_CLIENT_SECRET", "WRAZZ_OIDC_REDIRECT_URI"]
+        .iter()
+        .all(|k| std::env::var(k).is_ok())
+}

--- a/modules/wrazz-server/src/routes/mod.rs
+++ b/modules/wrazz-server/src/routes/mod.rs
@@ -17,6 +17,7 @@
 /// - `POST   /api/files`               — create file
 /// - `PUT    /api/files/{*path}`        — update file
 /// - `POST   /api/dirs`                — create directory
+pub mod admin;
 pub mod auth;
 pub mod files;
 pub mod oidc;
@@ -35,12 +36,17 @@ pub fn router(state: AppState, static_dir: Option<String>) -> Router {
         .route("/login", post(auth::login))
         .route("/logout", post(auth::logout))
         .route("/oidc/redirect", get(oidc::oidc_redirect))
-        .route("/oidc/callback", get(oidc::oidc_callback));
+        .route("/oidc/callback", get(oidc::oidc_callback))
+        .route("/oidc/status", get(oidc::oidc_status));
 
     let user_routes = Router::new()
         .route("/user", post(user::create_user))
         .route("/user/self", get(user::get_user_self))
         .route("/user/{handle}", get(user::get_user_by_handle));
+
+    let admin_routes = Router::new()
+        .route("/admin/oidc",
+            get(admin::get_oidc).put(admin::put_oidc).delete(admin::delete_oidc));
 
     let entry_routes = Router::new()
         .route("/entries", get(files::list_entries))
@@ -58,6 +64,7 @@ pub fn router(state: AppState, static_dir: Option<String>) -> Router {
     let api = Router::new()
         .nest("/auth", auth_routes)
         .merge(user_routes)
+        .merge(admin_routes)
         .merge(entry_routes)
         .merge(file_routes)
         .merge(content_routes)

--- a/modules/wrazz-server/src/routes/oidc.rs
+++ b/modules/wrazz-server/src/routes/oidc.rs
@@ -1,13 +1,16 @@
 use std::{
     collections::HashMap,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
 use axum::{
+    Json,
     extract::{Query, State},
     http::StatusCode,
     response::Redirect,
 };
+use serde::Serialize;
 use axum_extra::extract::cookie::{Cookie, CookieJar};
 use openidconnect::{
     AuthenticationFlow,
@@ -97,6 +100,18 @@ pub struct CallbackParams {
     state: String,
 }
 
+/// `GET /api/auth/oidc/status` — unauthenticated probe used by the login page
+/// to decide whether to show the SSO button.
+#[derive(Serialize)]
+pub struct OidcStatusResponse {
+    pub enabled: bool,
+}
+
+pub async fn oidc_status(State(state): State<AppState>) -> Json<OidcStatusResponse> {
+    let enabled = state.oidc_provider.read().await.is_some();
+    Json(OidcStatusResponse { enabled })
+}
+
 /// `GET /api/auth/oidc/redirect` — begins the authorization code flow.
 ///
 /// Generates a fresh CSRF token, nonce, and PKCE challenge, stores the
@@ -105,10 +120,10 @@ pub struct CallbackParams {
 pub async fn oidc_redirect(
     State(state): State<AppState>,
 ) -> Result<Redirect, (StatusCode, &'static str)> {
-    let provider = state
-        .oidc_provider
-        .as_ref()
-        .ok_or((StatusCode::NOT_IMPLEMENTED, "OIDC not configured"))?;
+    let provider = {
+        let guard = state.oidc_provider.read().await;
+        Arc::clone(guard.as_ref().ok_or((StatusCode::NOT_IMPLEMENTED, "OIDC not configured"))?)
+    };
 
     let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
     let (auth_url, csrf_token, nonce) = provider
@@ -152,10 +167,10 @@ pub async fn oidc_callback(
     State(state): State<AppState>,
     Query(params): Query<CallbackParams>,
 ) -> Result<(CookieJar, Redirect), (StatusCode, String)> {
-    let provider = state
-        .oidc_provider
-        .as_ref()
-        .ok_or_else(|| (StatusCode::NOT_IMPLEMENTED, "OIDC not configured".into()))?;
+    let provider = {
+        let guard = state.oidc_provider.read().await;
+        Arc::clone(guard.as_ref().ok_or_else(|| (StatusCode::NOT_IMPLEMENTED, "OIDC not configured".to_string()))?)
+    };
 
     let pending = provider
         .pending

--- a/modules/wrazz-server/src/state.rs
+++ b/modules/wrazz-server/src/state.rs
@@ -2,23 +2,28 @@ use std::sync::Arc;
 
 use chrono::Duration;
 use sqlx::SqlitePool;
+use tokio::sync::RwLock;
 
 use crate::routes::oidc::OidcProvider;
 use crate::store_cache::StoreCache;
 
 /// Shared server state injected into every Axum handler via [`State`].
 ///
-/// `AppState` is cheap to clone (all heavy resources are behind `Arc` or are
-/// themselves clone-by-reference like `SqlitePool`), so each handler receives
-/// its own copy rather than a shared reference.
+/// `AppState` is cheap to clone — all heavy resources are behind `Arc`.
+/// `oidc_provider` is behind `Arc<RwLock<...>>` so the admin UI can hot-swap
+/// the provider at runtime without a server restart.
 ///
 /// [`State`]: axum::extract::State
 #[derive(Clone)]
 pub struct AppState {
     pub pool: SqlitePool,
     pub store_cache: Arc<StoreCache>,
-    /// `None` when the `WRAZZ_OIDC_*` env vars are absent or discovery fails.
-    /// OIDC routes return `501 Not Implemented` in that case.
-    pub oidc_provider: Option<Arc<OidcProvider>>,
+    /// Hot-swappable OIDC provider. `None` when OIDC is not configured or
+    /// discovery failed. The admin API writes through this lock; OIDC request
+    /// handlers clone the inner `Arc` and release the lock before awaiting.
+    pub oidc_provider: Arc<RwLock<Option<Arc<OidcProvider>>>>,
     pub session_duration: Duration,
+    /// The public base URL of this instance (e.g. `https://wrazz.home.fraley.dev`),
+    /// set via `WRAZZ_PUBLIC_URL`. Used to suggest the OIDC redirect URI in the UI.
+    pub public_url: Option<String>,
 }


### PR DESCRIPTION
## Summary

- Profile and Administration modals in the user dropdown (admin-only for Administration)
- Administration modal: Info page + SSO configuration page
- OIDC admin UI: configure single sign-on at runtime without a server restart
- App chrome polish: three-tier background hierarchy, stronger topbar borders
- Generic `Modal` base component; modals live in `components/modals/`

## Backend changes

- `oidc_config` SQLite table (singleton row) for runtime SSO config
- `Arc<RwLock<Option<Arc<OidcProvider>>>>` makes the provider hot-swappable
- `GET/PUT/DELETE /api/admin/oidc` (admin-only); `PUT` runs discovery before writing to DB; env vars take precedence and cause `PUT`/`DELETE` to return 409
- `GET /api/auth/oidc/status` (unauthenticated) for login page SSO button probe
- `WRAZZ_PUBLIC_URL` env var; redirect URI is computed from it, not user-settable
- Startup loads OIDC from env vars first, DB config second

## Frontend changes

- SSO page: status indicator, issuer/client-id/secret fields, computed redirect URI read-only, env-var notice greys out form
- Login page probes status endpoint and shows SSO button when enabled
- Resolves #8 (both phases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)