### PR TITLE
chore(ci): stop pushing mutable :main tag to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=ref,event=branch
             type=sha,prefix=sha-,format=short
 
       - name: Build and push


### PR DESCRIPTION
Removes `type=ref,event=branch` from the metadata-action config so CI only ever pushes semver tags (`0.1.2`, `0.1`) and sha-prefixed tags (`sha-abc1234`). The mutable `:main` tag is gone going forward — see `wrazz-server:main` in GHCR to delete the existing stale one.