### PR TITLE
feat: email-based OIDC linking, no auto-provisioning, user management

### DIFF
--- a/modules/wrazz-frontend/src/App.tsx
+++ b/modules/wrazz-frontend/src/App.tsx
@@ -110,6 +110,7 @@ export default function App() {
           onDelete={handleDelete}
           user={user}
           onLogout={handleLogout}
+          onUserUpdated={setUser}
         />
       </div>
       <StatusBar title={draft?.title ?? null} status={status} />

--- a/modules/wrazz-frontend/src/api/admin.ts
+++ b/modules/wrazz-frontend/src/api/admin.ts
@@ -50,3 +50,22 @@ export async function getOidcStatus(): Promise<OidcStatus> {
   if (!resp.ok) return { enabled: false };
   return resp.json();
 }
+
+export interface AdminUser {
+  id: string;
+  display_name: string;
+  email: string | null;
+  is_admin: boolean;
+  created_at: string;
+}
+
+export async function listUsers(): Promise<AdminUser[]> {
+  const resp = await fetch("/api/admin/users");
+  if (!resp.ok) throw new Error(`list users failed: ${resp.status}`);
+  return resp.json();
+}
+
+export async function deleteUser(id: string): Promise<void> {
+  const resp = await fetch(`/api/admin/users/${id}`, { method: "DELETE" });
+  if (!resp.ok) throw new Error(`delete user failed: ${resp.status}`);
+}

--- a/modules/wrazz-frontend/src/api/auth.ts
+++ b/modules/wrazz-frontend/src/api/auth.ts
@@ -3,6 +3,7 @@ export interface CurrentUser {
   display_name: string;
   is_admin: boolean;
   created_at: string;
+  email: string | null;
 }
 
 /// Returns the current user if a valid session cookie exists, otherwise null.

--- a/modules/wrazz-frontend/src/api/user.ts
+++ b/modules/wrazz-frontend/src/api/user.ts
@@ -1,0 +1,12 @@
+import type { CurrentUser } from "./auth";
+
+export async function updateSelf(email: string | null): Promise<CurrentUser> {
+  const resp = await fetch("/api/user/self", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email }),
+  });
+  if (resp.status === 409) throw new Error("That email is already in use.");
+  if (!resp.ok) throw new Error(`update failed: ${resp.status}`);
+  return resp.json();
+}

--- a/modules/wrazz-frontend/src/components/Editor.tsx
+++ b/modules/wrazz-frontend/src/components/Editor.tsx
@@ -22,6 +22,7 @@ interface Props {
   onDelete: () => void;
   user: CurrentUser;
   onLogout: () => void;
+  onUserUpdated: (user: CurrentUser) => void;
 }
 
 export default function Editor({
@@ -32,6 +33,7 @@ export default function Editor({
   onDelete,
   user,
   onLogout,
+  onUserUpdated,
 }: Props) {
   const menuRef = useRef<HTMLDetailsElement>(null);
   const [modal, setModal] = useState<Modal>(null);
@@ -57,10 +59,14 @@ export default function Editor({
         </details>
       </div>
       {modal === "profile" && (
-        <ProfileModal user={user} onClose={() => setModal(null)} />
+        <ProfileModal
+          user={user}
+          onClose={() => setModal(null)}
+          onUpdated={(u) => { onUserUpdated(u); }}
+        />
       )}
       {modal === "admin" && (
-        <AdminModal onClose={() => setModal(null)} />
+        <AdminModal onClose={() => setModal(null)} currentUserId={user.id} />
       )}
 
       {!file || !draft ? (

--- a/modules/wrazz-frontend/src/components/modals/AdminModal.tsx
+++ b/modules/wrazz-frontend/src/components/modals/AdminModal.tsx
@@ -1,20 +1,24 @@
 import { FormEvent, useEffect, useState } from "react";
 import Modal from "./Modal";
 import {
+  AdminUser,
   OidcConfig,
   SECRET_REDACTED,
   deleteOidcConfig,
+  deleteUser,
   getOidcConfig,
+  listUsers,
   saveOidcConfig,
 } from "../../api/admin";
 
-type AdminPage = "info" | "sso";
+type AdminPage = "info" | "sso" | "users";
 
 interface Props {
   onClose: () => void;
+  currentUserId: string;
 }
 
-export default function AdminModal({ onClose }: Props) {
+export default function AdminModal({ onClose, currentUserId }: Props) {
   const [page, setPage] = useState<AdminPage>("info");
 
   return (
@@ -33,10 +37,17 @@ export default function AdminModal({ onClose }: Props) {
           >
             SSO
           </button>
+          <button
+            className={`admin-nav-item${page === "users" ? " active" : ""}`}
+            onClick={() => setPage("users")}
+          >
+            Users
+          </button>
         </nav>
         <div className="admin-section">
           {page === "info" && <InfoPage />}
           {page === "sso" && <SsoPage />}
+          {page === "users" && <UsersPage currentUserId={currentUserId} />}
         </div>
       </div>
     </Modal>
@@ -270,5 +281,59 @@ function SsoPage() {
         </div>
       )}
     </form>
+  );
+}
+
+function UsersPage({ currentUserId }: { currentUserId: string }) {
+  const [users, setUsers] = useState<AdminUser[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  useEffect(() => {
+    listUsers()
+      .then(setUsers)
+      .catch(() => setError("Could not load users."));
+  }, []);
+
+  async function handleDelete(user: AdminUser) {
+    if (!window.confirm(`Delete account "${user.display_name}"? This cannot be undone.`)) return;
+    setDeleting(user.id);
+    try {
+      await deleteUser(user.id);
+      setUsers((u) => u?.filter((x) => x.id !== user.id) ?? null);
+    } catch {
+      setError("Could not delete user.");
+    } finally {
+      setDeleting(null);
+    }
+  }
+
+  if (error) return <p className="admin-users-error">{error}</p>;
+  if (!users) return <p className="admin-users-loading">Loading…</p>;
+
+  return (
+    <div className="admin-users">
+      {users.map((u) => (
+        <div key={u.id} className="admin-user-row">
+          <div className="admin-user-info">
+            <span className="admin-user-name">{u.display_name}</span>
+            {u.is_admin && <span className="admin-user-badge">Admin</span>}
+            <span className="admin-user-email">
+              {u.email ?? <em className="admin-user-email--unset">no email set</em>}
+            </span>
+          </div>
+          {u.id !== currentUserId && (
+            <button
+              className="admin-user-delete"
+              onClick={() => handleDelete(u)}
+              disabled={deleting === u.id}
+              aria-label={`Delete ${u.display_name}`}
+            >
+              {deleting === u.id ? "…" : "Delete"}
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
   );
 }

--- a/modules/wrazz-frontend/src/components/modals/ProfileModal.tsx
+++ b/modules/wrazz-frontend/src/components/modals/ProfileModal.tsx
@@ -1,17 +1,42 @@
+import { FormEvent, useState } from "react";
 import type { CurrentUser } from "../../api/auth";
+import { updateSelf } from "../../api/user";
 import Modal from "./Modal";
 
 interface Props {
   user: CurrentUser;
   onClose: () => void;
+  onUpdated: (user: CurrentUser) => void;
 }
 
-export default function ProfileModal({ user, onClose }: Props) {
+export default function ProfileModal({ user, onClose, onUpdated }: Props) {
+  const [email, setEmail] = useState(user.email ?? "");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
   const memberSince = new Date(user.created_at).toLocaleDateString("en-US", {
     year: "numeric",
     month: "long",
     day: "numeric",
   });
+
+  async function handleSaveEmail(e: FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const updated = await updateSelf(email.trim() || null);
+      onUpdated(updated);
+      setEmail(updated.email ?? "");
+      setSuccess("Email saved.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
 
   return (
     <Modal title="Profile" onClose={onClose}>
@@ -30,6 +55,36 @@ export default function ProfileModal({ user, onClose }: Props) {
             <span className="profile-label">Role</span>
             <span className="profile-value">{user.is_admin ? "Admin" : "Member"}</span>
           </div>
+
+          <form className="profile-email-form" onSubmit={handleSaveEmail}>
+            <div className="profile-field">
+              <label className="profile-label" htmlFor="profile-email">Email</label>
+              <div className="profile-email-row">
+                <input
+                  id="profile-email"
+                  className="profile-email-input"
+                  type="email"
+                  value={email}
+                  onChange={(e) => {
+                    setEmail(e.target.value);
+                    setError(null);
+                    setSuccess(null);
+                  }}
+                  placeholder="you@example.com"
+                  disabled={busy}
+                />
+                <button
+                  type="submit"
+                  className="profile-email-save"
+                  disabled={busy || email.trim() === (user.email ?? "")}
+                >
+                  {busy ? "Saving…" : "Save"}
+                </button>
+              </div>
+              {error && <p className="profile-email-msg profile-email-msg--error">{error}</p>}
+              {success && <p className="profile-email-msg profile-email-msg--ok">{success}</p>}
+            </div>
+          </form>
         </div>
       </div>
     </Modal>

--- a/modules/wrazz-frontend/src/index.css
+++ b/modules/wrazz-frontend/src/index.css
@@ -597,6 +597,162 @@ body {
   text-decoration: underline;
 }
 
+/* Admin users page */
+
+.admin-users {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.admin-users-loading,
+.admin-users-error {
+  font-size: 13px;
+  font-family: ui-monospace, monospace;
+  color: var(--ink-muted);
+}
+
+.admin-users-error { color: var(--danger); }
+
+.admin-user-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 3px;
+}
+
+.admin-user-row:hover {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.admin-user-info {
+  flex: 1;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+
+.admin-user-name {
+  font-size: 15px;
+  font-family: Georgia, "Times New Roman", serif;
+  color: var(--ink);
+  flex-shrink: 0;
+}
+
+.admin-user-badge {
+  font-size: 10px;
+  font-family: ui-monospace, monospace;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  padding: 1px 5px;
+  flex-shrink: 0;
+}
+
+.admin-user-email {
+  font-size: 13px;
+  font-family: ui-monospace, monospace;
+  color: var(--ink-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-user-email--unset {
+  font-style: italic;
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+.admin-user-delete {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-family: ui-monospace, monospace;
+  color: var(--ink-muted);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 4px 10px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.admin-user-delete:hover {
+  color: var(--danger);
+  border-color: var(--danger);
+}
+
+.admin-user-delete:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* Profile email edit */
+
+.profile-email-form {
+  margin: 0;
+}
+
+.profile-email-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.profile-email-input {
+  flex: 1;
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: ui-monospace, monospace;
+  font-size: 14px;
+  outline: none;
+}
+
+.profile-email-input:focus {
+  border-color: var(--ink-muted);
+}
+
+.profile-email-input:disabled {
+  opacity: 0.5;
+}
+
+.profile-email-save {
+  flex-shrink: 0;
+  padding: 7px 14px;
+  font-size: 12px;
+  font-family: ui-monospace, monospace;
+  border: 1px solid var(--border-strong);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+}
+
+.profile-email-save:hover {
+  border-color: var(--ink-muted);
+}
+
+.profile-email-save:disabled {
+  opacity: 0.5;
+  cursor: default;
+  border-color: var(--border);
+  color: var(--ink-muted);
+}
+
+.profile-email-msg {
+  font-size: 12px;
+  font-family: ui-monospace, monospace;
+  margin-top: 5px;
+}
+
+.profile-email-msg--error { color: var(--danger); }
+.profile-email-msg--ok    { color: #5a8060; }
+
 /* SSO configuration form */
 
 .sso-form {

--- a/modules/wrazz-server/migrations/20260428000000_add_user_email.sql
+++ b/modules/wrazz-server/migrations/20260428000000_add_user_email.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users ADD COLUMN email TEXT;
+
+-- Partial unique index so NULL emails don't conflict with each other.
+CREATE UNIQUE INDEX users_email_idx ON users(email) WHERE email IS NOT NULL;

--- a/modules/wrazz-server/src/db.rs
+++ b/modules/wrazz-server/src/db.rs
@@ -50,6 +50,7 @@ struct UserWithHash {
     display_name: String,
     created_at: DateTime<Utc>,
     is_admin: bool,
+    email: Option<String>,
     credential_hash: Option<String>,
 }
 
@@ -57,7 +58,7 @@ struct UserWithHash {
 
 pub async fn get_user_by_id(pool: &SqlitePool, id: Uuid) -> sqlx::Result<Option<User>> {
     sqlx::query_as::<_, User>(
-        "SELECT id, display_name, created_at, is_admin FROM users WHERE id = ?",
+        "SELECT id, display_name, created_at, is_admin, email FROM users WHERE id = ?",
     )
     .bind(id)
     .fetch_optional(pool)
@@ -82,7 +83,7 @@ pub async fn get_user_by_password_subject(
 ) -> sqlx::Result<Option<(User, String)>> {
     let row = sqlx::query_as::<_, UserWithHash>(
         r#"
-        SELECT u.id, u.display_name, u.created_at, u.is_admin, p.credential_hash
+        SELECT u.id, u.display_name, u.created_at, u.is_admin, u.email, p.credential_hash
         FROM users u
         JOIN user_auth_providers p ON p.user_id = u.id
         WHERE p.provider = 'password' AND p.subject = ? AND p.credential_hash IS NOT NULL
@@ -100,6 +101,7 @@ pub async fn get_user_by_password_subject(
                     display_name: r.display_name,
                     created_at: r.created_at,
                     is_admin: r.is_admin,
+                    email: r.email,
                 },
                 hash,
             )
@@ -113,13 +115,24 @@ pub async fn get_user_by_oidc_subject(
 ) -> sqlx::Result<Option<User>> {
     sqlx::query_as::<_, User>(
         r#"
-        SELECT u.id, u.display_name, u.created_at, u.is_admin
+        SELECT u.id, u.display_name, u.created_at, u.is_admin, u.email
         FROM users u
         JOIN user_auth_providers p ON p.user_id = u.id
         WHERE p.provider = 'oidc' AND p.subject = ?
         "#,
     )
     .bind(sub)
+    .fetch_optional(pool)
+    .await
+}
+
+/// Looks up a user by their email address. Used as a fallback in the OIDC
+/// callback to link a new OIDC sub to an existing password account.
+pub async fn get_user_by_email(pool: &SqlitePool, email: &str) -> sqlx::Result<Option<User>> {
+    sqlx::query_as::<_, User>(
+        "SELECT id, display_name, created_at, is_admin, email FROM users WHERE email = ?",
+    )
+    .bind(email)
     .fetch_optional(pool)
     .await
 }
@@ -160,49 +173,59 @@ pub async fn create_user_with_password(
 
     // Fetch back to pick up the server-side created_at default.
     sqlx::query_as::<_, User>(
-        "SELECT id, display_name, created_at, is_admin FROM users WHERE id = ?",
+        "SELECT id, display_name, created_at, is_admin, email FROM users WHERE id = ?",
     )
     .bind(user_id)
     .fetch_one(pool)
     .await
 }
 
-/// Creates a new user and an `'oidc'` auth provider row in a single
-/// transaction. Called during OIDC callback when no existing user matches the
-/// provider's `sub` claim (auto-provisioning).
-pub async fn create_user_with_oidc(
-    pool: &SqlitePool,
-    display_name: &str,
-    sub: &str,
-) -> sqlx::Result<User> {
-    let user_id = Uuid::new_v4();
-    let mut tx = pool.begin().await?;
-
-    sqlx::query(
-        "INSERT INTO users (id, display_name) VALUES (?, ?)",
-    )
-    .bind(user_id)
-    .bind(display_name)
-    .execute(&mut *tx)
-    .await?;
-
+/// Adds an OIDC auth provider row to an existing user. Called when the OIDC
+/// callback matches an existing user by email rather than by sub claim —
+/// subsequent logins will match by sub and skip the email lookup.
+pub async fn link_oidc_to_user(pool: &SqlitePool, user_id: Uuid, sub: &str) -> sqlx::Result<()> {
     sqlx::query(
         "INSERT INTO user_auth_providers (id, user_id, provider, subject) VALUES (?, ?, 'oidc', ?)",
     )
     .bind(Uuid::new_v4())
     .bind(user_id)
     .bind(sub)
-    .execute(&mut *tx)
+    .execute(pool)
     .await?;
+    Ok(())
+}
 
-    tx.commit().await?;
+/// Sets or clears the email address on a user record.
+pub async fn set_user_email(
+    pool: &SqlitePool,
+    user_id: Uuid,
+    email: Option<&str>,
+) -> sqlx::Result<()> {
+    sqlx::query("UPDATE users SET email = ? WHERE id = ?")
+        .bind(email)
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
 
+/// Returns all users ordered by creation date ascending.
+pub async fn list_users(pool: &SqlitePool) -> sqlx::Result<Vec<User>> {
     sqlx::query_as::<_, User>(
-        "SELECT id, display_name, created_at, is_admin FROM users WHERE id = ?",
+        "SELECT id, display_name, created_at, is_admin, email FROM users ORDER BY created_at ASC",
     )
-    .bind(user_id)
-    .fetch_one(pool)
+    .fetch_all(pool)
     .await
+}
+
+/// Deletes a user and all cascading rows (sessions, auth providers, workspaces).
+/// Files on disk are not removed.
+pub async fn delete_user(pool: &SqlitePool, user_id: Uuid) -> sqlx::Result<()> {
+    sqlx::query("DELETE FROM users WHERE id = ?")
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+    Ok(())
 }
 
 // --- OIDC config queries ---
@@ -283,7 +306,7 @@ pub async fn create_session(
 pub async fn get_session_user(pool: &SqlitePool, session_id: Uuid) -> sqlx::Result<Option<User>> {
     sqlx::query_as::<_, User>(
         r#"
-        SELECT u.id, u.display_name, u.created_at, u.is_admin
+        SELECT u.id, u.display_name, u.created_at, u.is_admin, u.email
         FROM users u
         JOIN sessions s ON s.user_id = u.id
         WHERE s.id = ? AND s.expires_at > unixepoch('now')

--- a/modules/wrazz-server/src/lib.rs
+++ b/modules/wrazz-server/src/lib.rs
@@ -40,4 +40,9 @@ pub struct User {
     /// any user by ID. The first admin is provisioned at startup via
     /// `WRAZZ_BOOTSTRAP_ADMIN`.
     pub is_admin: bool,
+    /// Contact email. Used as a fallback key for linking OIDC logins to
+    /// existing password accounts: if an OIDC sub claim is unrecognised, the
+    /// callback matches by email and links the provider rather than creating
+    /// a new account.
+    pub email: Option<String>,
 }

--- a/modules/wrazz-server/src/routes/admin.rs
+++ b/modules/wrazz-server/src/routes/admin.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
-use axum::{Json, extract::State, http::StatusCode};
+use axum::{Json, extract::{Path, State}, http::StatusCode};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use wrazz_server::User;
 
 use crate::db::{self, OidcConfig};
 use crate::routes::auth::AuthUser;
@@ -182,6 +184,34 @@ pub async fn delete_oidc(
 
     *state.oidc_provider.write().await = None;
 
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /api/admin/users` — list all user accounts.
+pub async fn list_users(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> Result<Json<Vec<User>>, (StatusCode, String)> {
+    require_admin(&auth_user)?;
+    let users = db::list_users(&state.pool).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(users))
+}
+
+/// `DELETE /api/admin/users/{id}` — delete a user account.
+///
+/// Returns 400 if the caller tries to delete their own account.
+pub async fn delete_user(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    require_admin(&auth_user)?;
+    if auth_user.0.id == id {
+        return Err((StatusCode::BAD_REQUEST, "cannot delete your own account".into()));
+    }
+    db::delete_user(&state.pool, id).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/modules/wrazz-server/src/routes/mod.rs
+++ b/modules/wrazz-server/src/routes/mod.rs
@@ -41,12 +41,14 @@ pub fn router(state: AppState, static_dir: Option<String>) -> Router {
 
     let user_routes = Router::new()
         .route("/user", post(user::create_user))
-        .route("/user/self", get(user::get_user_self))
+        .route("/user/self", get(user::get_user_self).put(user::update_user_self))
         .route("/user/{handle}", get(user::get_user_by_handle));
 
     let admin_routes = Router::new()
         .route("/admin/oidc",
-            get(admin::get_oidc).put(admin::put_oidc).delete(admin::delete_oidc));
+            get(admin::get_oidc).put(admin::put_oidc).delete(admin::delete_oidc))
+        .route("/admin/users", get(admin::list_users))
+        .route("/admin/users/{id}", delete(admin::delete_user));
 
     let entry_routes = Router::new()
         .route("/entries", get(files::list_entries))

--- a/modules/wrazz-server/src/routes/oidc.rs
+++ b/modules/wrazz-server/src/routes/oidc.rs
@@ -135,6 +135,7 @@ pub async fn oidc_redirect(
         )
         .add_scope(Scope::new("openid".into()))
         .add_scope(Scope::new("profile".into()))
+        .add_scope(Scope::new("email".into()))
         .set_pkce_challenge(pkce_challenge)
         .url();
 
@@ -200,22 +201,42 @@ pub async fn oidc_callback(
         .map_err(|e| (StatusCode::UNAUTHORIZED, e.to_string()))?;
 
     let sub = claims.subject().as_str().to_string();
+    let email = claims.email().map(|e| e.as_str().to_string());
 
-    // Find existing user or auto-provision one from the OIDC claims.
+    // 1. Match by OIDC subject (fast path — covers all logins after the first).
+    // 2. Match by email (first-time SSO login for an existing password account).
+    //    On match, link the sub so future logins hit path 1.
+    // 3. No match → reject. Auto-provisioning is disabled; accounts must be
+    //    created by an admin and have their email set before SSO can be used.
     let user = match db::get_user_by_oidc_subject(&state.pool, &sub)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
     {
         Some(u) => u,
         None => {
-            let display_name = claims
-                .preferred_username()
-                .map(|u| u.as_str().to_string())
-                .unwrap_or_else(|| sub.clone());
-
-            db::create_user_with_oidc(&state.pool, &display_name, &sub)
-                .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+            match email.as_deref() {
+                Some(email_str) => {
+                    match db::get_user_by_email(&state.pool, email_str)
+                        .await
+                        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+                    {
+                        Some(u) => {
+                            db::link_oidc_to_user(&state.pool, u.id, &sub)
+                                .await
+                                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+                            u
+                        }
+                        None => return Err((
+                            StatusCode::FORBIDDEN,
+                            "No account found for this SSO identity. Ask an administrator to create an account and set your email address.".into(),
+                        )),
+                    }
+                }
+                None => return Err((
+                    StatusCode::FORBIDDEN,
+                    "No account found for this SSO identity. Ask an administrator to create an account and set your email address.".into(),
+                )),
+            }
         }
     };
 

--- a/modules/wrazz-server/src/routes/user.rs
+++ b/modules/wrazz-server/src/routes/user.rs
@@ -27,6 +27,11 @@ pub struct CreateUserRequest {
     pub display_name: String,
 }
 
+#[derive(Deserialize)]
+pub struct UpdateSelfRequest {
+    pub email: Option<String>,
+}
+
 // --- Handlers ---
 
 /// `POST /api/user` — create a new password-auth account.
@@ -71,6 +76,33 @@ pub async fn create_user(
 /// `GET /api/user/self` — return the authenticated caller's own user record.
 pub async fn get_user_self(auth_user: AuthUser) -> Json<User> {
     Json(auth_user.0)
+}
+
+/// `PUT /api/user/self` — update the caller's email address.
+///
+/// Pass `null` to clear the email. Returns 409 if the address is taken.
+pub async fn update_user_self(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Json(req): Json<UpdateSelfRequest>,
+) -> Result<Json<User>, (StatusCode, String)> {
+    db::set_user_email(&state.pool, auth_user.0.id, req.email.as_deref())
+        .await
+        .map_err(|e| {
+            if let sqlx::Error::Database(ref dbe) = e {
+                if dbe.is_unique_violation() {
+                    return (StatusCode::CONFLICT, "email already in use".into());
+                }
+            }
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+        })?;
+
+    let user = db::get_user_by_id(&state.pool, auth_user.0.id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or_else(|| (StatusCode::NOT_FOUND, "user not found".into()))?;
+
+    Ok(Json(user))
 }
 
 /// `GET /api/user/id:<uuid>` — look up a user by their UUID.


### PR DESCRIPTION
## Summary

- OIDC callback now matches by sub first, email second; on email match it links the OIDC sub to the existing account so future logins go via sub. If neither matches → 403 (no auto-provisioning).
- `email` scope added to the authorization request so Authentik provides the claim.
- `PUT /api/user/self` lets users set their email from the Profile modal — required before OIDC linking will work for existing password accounts.
- `GET /api/admin/users` + `DELETE /api/admin/users/{id}` for user management (admin-only).
- Profile modal: editable email field.
- Administration modal: Users page with per-row delete.

Resolves the ghost-account issue from the first SSO login attempt.
🤖 Generated with [Claude Code](https://claude.com/claude-code)