### PR TITLE
fix: make file title properly nullable

### DIFF
--- a/modules/wrazz-backend/src/http_backend.rs
+++ b/modules/wrazz-backend/src/http_backend.rs
@@ -126,7 +126,7 @@ impl Backend for HttpBackend {
         &self,
         workspace: &str,
         path: &str,
-        title: String,
+        title: Option<String>,
         tags: Vec<String>,
         content: String,
     ) -> BackendResult<FileEntry> {
@@ -153,7 +153,7 @@ impl Backend for HttpBackend {
         &self,
         workspace: &str,
         path: &str,
-        title: String,
+        title: Option<String>,
         tags: Vec<String>,
         content: String,
     ) -> BackendResult<FileEntry> {

--- a/modules/wrazz-backend/src/local_backend.rs
+++ b/modules/wrazz-backend/src/local_backend.rs
@@ -63,7 +63,7 @@ impl Backend for LocalBackend {
         &self,
         workspace: &str,
         path: &str,
-        title: String,
+        title: Option<String>,
         tags: Vec<String>,
         content: String,
     ) -> BackendResult<FileEntry> {
@@ -75,7 +75,7 @@ impl Backend for LocalBackend {
         &self,
         workspace: &str,
         path: &str,
-        title: String,
+        title: Option<String>,
         tags: Vec<String>,
         content: String,
     ) -> BackendResult<FileEntry> {

--- a/modules/wrazz-backend/src/routes.rs
+++ b/modules/wrazz-backend/src/routes.rs
@@ -76,7 +76,8 @@ fn root_path() -> String { "/".to_string() }
 
 #[derive(Deserialize)]
 struct CreateFileRequest {
-    title: String,
+    #[serde(default)]
+    title: Option<String>,
     #[serde(default)]
     tags: Vec<String>,
     content: String,
@@ -84,7 +85,8 @@ struct CreateFileRequest {
 
 #[derive(Deserialize)]
 struct UpdateFileRequest {
-    title: String,
+    #[serde(default)]
+    title: Option<String>,
     #[serde(default)]
     tags: Vec<String>,
     content: String,

--- a/modules/wrazz-backend/src/store.rs
+++ b/modules/wrazz-backend/src/store.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -26,7 +26,8 @@ pub type StoreResult<T> = Result<T, StoreError>;
 // Deserialised from a file's YAML front matter block.
 #[derive(Deserialize)]
 struct FrontMatter {
-    title: String,
+    #[serde(default)]
+    title: Option<String>,
     #[serde(default)]
     tags: Vec<String>,
     created_at: DateTime<Utc>,
@@ -35,7 +36,8 @@ struct FrontMatter {
 // Serialised into a file's YAML front matter block.
 #[derive(Serialize)]
 struct FrontMatterOut<'a> {
-    title: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<&'a str>,
     #[serde(skip_serializing_if = "slice_is_empty")]
     tags: &'a [String],
     created_at: String,
@@ -204,21 +206,16 @@ impl Store {
 
             Ok(FileEntry {
                 path: abs_path,
-                title: fm.title,
+                title: fm.title.filter(|t| !t.is_empty()),
                 tags: fm.tags,
                 created_at: fm.created_at,
                 updated_at,
             })
         } else {
-            let title = raw
-                .lines()
-                .find(|l| l.starts_with("# "))
-                .map(|l| l[2..].trim().to_string())
-                .unwrap_or_else(|| stem_from_path(rel_path));
-
+            // No front matter → no title set; frontend shows a placeholder.
             Ok(FileEntry {
                 path: abs_path,
-                title,
+                title: None,
                 tags: Vec::new(),
                 created_at: updated_at,
                 updated_at,
@@ -226,14 +223,14 @@ impl Store {
         }
     }
 
-    fn serialize(title: &str, tags: &[String], created_at: &DateTime<Utc>, content: &str) -> String {
-        // No title and no tags → write a naked file. created_at is recovered
-        // from filesystem mtime, same as any other foreign Markdown file.
-        if title.is_empty() && tags.is_empty() {
+    fn serialize(title: Option<&str>, tags: &[String], created_at: &DateTime<Utc>, content: &str) -> String {
+        let effective_title = title.map(str::trim).filter(|t| !t.is_empty());
+        // No title and no tags → write a naked file (no front matter).
+        if effective_title.is_none() && tags.is_empty() {
             return content.to_string();
         }
         let fm = FrontMatterOut {
-            title,
+            title: effective_title,
             tags,
             created_at: created_at.to_rfc3339(),
         };
@@ -247,7 +244,7 @@ impl Store {
     pub async fn create(
         &self,
         rel_path: &str,
-        title: String,
+        title: Option<String>,
         tags: Vec<String>,
         content: String,
     ) -> StoreResult<FileEntry> {
@@ -262,7 +259,7 @@ impl Store {
         }
 
         let now = Utc::now();
-        fs::write(&path, Self::serialize(&title, &tags, &now, &content))
+        fs::write(&path, Self::serialize(title.as_deref(), &tags, &now, &content))
             .await
             .map_err(StoreError::Io)?;
 
@@ -273,7 +270,7 @@ impl Store {
     pub async fn save(
         &self,
         rel_path: &str,
-        title: String,
+        title: Option<String>,
         tags: Vec<String>,
         content: String,
     ) -> StoreResult<FileEntry> {
@@ -282,7 +279,7 @@ impl Store {
 
         fs::write(
             &path,
-            Self::serialize(&title, &tags, &existing.created_at, &content),
+            Self::serialize(title.as_deref(), &tags, &existing.created_at, &content),
         )
         .await
         .map_err(StoreError::Io)?;
@@ -360,9 +357,3 @@ pub fn slugify(s: &str) -> String {
         .join("-")
 }
 
-fn stem_from_path(rel_path: &str) -> String {
-    Path::new(rel_path)
-        .file_stem()
-        .map(|s| s.to_string_lossy().into_owned())
-        .unwrap_or_else(|| rel_path.to_string())
-}

--- a/modules/wrazz-core/src/backend.rs
+++ b/modules/wrazz-core/src/backend.rs
@@ -47,7 +47,7 @@ pub trait Backend: Send + Sync {
         &self,
         workspace: &str,
         path: &str,
-        title: String,
+        title: Option<String>,
         tags: Vec<String>,
         content: String,
     ) -> BackendResult<FileEntry>;
@@ -57,7 +57,7 @@ pub trait Backend: Send + Sync {
         &self,
         workspace: &str,
         path: &str,
-        title: String,
+        title: Option<String>,
         tags: Vec<String>,
         content: String,
     ) -> BackendResult<FileEntry>;

--- a/modules/wrazz-core/src/entry.rs
+++ b/modules/wrazz-core/src/entry.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileEntry {
     pub path: String,
-    pub title: String,
+    pub title: Option<String>,
     #[serde(default)]
     pub tags: Vec<String>,
     pub created_at: DateTime<Utc>,

--- a/modules/wrazz-frontend/src/App.tsx
+++ b/modules/wrazz-frontend/src/App.tsx
@@ -73,7 +73,7 @@ export default function App() {
       ]);
       setActivePath(path);
       setActiveFile(file);
-      setDraft({ title: file.title, content, tags: file.tags });
+      setDraft({ title: file.title ?? "", content, tags: file.tags });
       setStatus(null);
     } catch {
       setStatus({ kind: "error", message: "Could not load file." });
@@ -83,7 +83,7 @@ export default function App() {
   async function handleSave() {
     if (!activePath || !draft) return;
     try {
-      const updated = await updateFile(activePath, draft.title, draft.tags, draft.content);
+      const updated = await updateFile(activePath, draft.title.trim() || null, draft.tags, draft.content);
       setActiveFile(updated);
       reload();
       setStatus({ kind: "ok", message: "Saved" });

--- a/modules/wrazz-frontend/src/api/files.ts
+++ b/modules/wrazz-frontend/src/api/files.ts
@@ -1,6 +1,6 @@
 export interface FileEntry {
   path: string;
-  title: string;
+  title: string | null;
   tags: string[];
   created_at: string;
   updated_at: string;
@@ -45,7 +45,7 @@ export async function getFileContent(path: string): Promise<FileContent> {
 
 export async function createFile(
   path: string,
-  title: string,
+  title: string | null,
   tags: string[],
   content: string,
 ): Promise<FileEntry> {
@@ -60,7 +60,7 @@ export async function createFile(
 
 export async function updateFile(
   path: string,
-  title: string,
+  title: string | null,
   tags: string[],
   content: string,
 ): Promise<FileEntry> {

--- a/modules/wrazz-frontend/src/components/FileTree.tsx
+++ b/modules/wrazz-frontend/src/components/FileTree.tsx
@@ -120,7 +120,7 @@ export default function FileTree({ activePath, onOpen, onDeleted, reloadKey, wid
       const name = i === 0 ? "untitled.md" : `untitled-${i + 1}.md`;
       const path = `${dir}/${name}`;
       try {
-        const file = await createFile(path, "", [], "");
+        const file = await createFile(path, null, [], "");
         await refreshDir(parentPath);
         setEditingPath(file.path);
         setEditValue(entryName(file.path));

--- a/modules/wrazz-server/src/routes/files.rs
+++ b/modules/wrazz-server/src/routes/files.rs
@@ -64,7 +64,8 @@ fn root_path() -> String { "/".to_string() }
 
 #[derive(Deserialize)]
 pub struct CreateFileRequest {
-    pub title: String,
+    #[serde(default)]
+    pub title: Option<String>,
     #[serde(default)]
     pub tags: Vec<String>,
     pub content: String,
@@ -72,7 +73,8 @@ pub struct CreateFileRequest {
 
 #[derive(Deserialize)]
 pub struct UpdateFileRequest {
-    pub title: String,
+    #[serde(default)]
+    pub title: Option<String>,
     #[serde(default)]
     pub tags: Vec<String>,
     pub content: String,


### PR DESCRIPTION
## Summary

- New files were showing \"untitled\" in the title input instead of the filename placeholder. Root cause: `parse_metadata` derived a title from the filename stem for naked files (no front matter), and `handleOpen` put it directly into `draft.title`, filling the input.
- `FileEntry.title` is now `Option<String>` (Rust) / `string | null` (TypeScript) throughout the entire stack — core types, backend trait, both backend impls, server route handlers, and frontend API layer
- Backend returns `None`/`null` for files with no explicit title in front matter; `serialize` normalizes `None`/empty → naked file so untitled files remain titleless on disk
- Frontend maps `null → ""` when building the draft (shows placeholder), and normalizes `"" → null` on save (doesn't write empty titles to front matter)
- Dropped the `stem_from_path` fallback — it conflicted with the placeholder design and the sidebar uses `entryName(path)` for display anyway

## Test plan

- [ ] Create a new file — title input should be empty with a filename-derived placeholder, not prefilled with \"untitled\"
- [ ] Type a title and save — file gains front matter with the title
- [ ] Clear the title field and save — front matter title is removed; file becomes naked again
- [ ] Open an existing file with a title — title input shows the saved title correctly
- [ ] Verify `cargo build` and `tsc --noEmit` pass (both clean)

Closes #7 (partially — draft persistence is a separate feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)