### PR TITLE
feat: export endpoints for file, directory, and workspace download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +51,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-io",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +71,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "async_zip"
+version = "0.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b9f7252833d5ed4b00aa9604b563529dd5e11de9c23615de2dcdf91eb87b52"
+dependencies = [
+ "async-compression",
+ "crc32fast",
+ "futures-lite",
+ "pin-project",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -269,6 +302,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +382,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -604,6 +662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +688,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -702,6 +776,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +819,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1381,6 +1480,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,6 +1706,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2351,6 +2480,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2861,6 +2996,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -3639,9 +3775,11 @@ version = "0.1.4"
 dependencies = [
  "argon2",
  "async-trait",
+ "async_zip",
  "axum",
  "axum-extra",
  "chrono",
+ "futures-util",
  "openidconnect",
  "reqwest 0.12.28",
  "serde",
@@ -3649,6 +3787,7 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/modules/wrazz-backend/src/store.rs
+++ b/modules/wrazz-backend/src/store.rs
@@ -320,6 +320,61 @@ impl Store {
         fs::create_dir_all(&path).await.map_err(StoreError::Io)
     }
 
+    /// Returns the raw bytes of the file at `rel_path`, exactly as stored on disk.
+    pub async fn read_raw(&self, rel_path: &str) -> StoreResult<Vec<u8>> {
+        let path = self.full_path(rel_path);
+        fs::read(&path).await.map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                StoreError::NotFound { path: rel_path.to_string() }
+            } else {
+                StoreError::Io(e)
+            }
+        })
+    }
+
+    /// Recursively collects the rel-paths of all `.md` files under `rel_path`.
+    ///
+    /// Uses an iterative DFS (explicit stack) to avoid async recursion boxing.
+    /// `rel_path` is relative to `data_dir`; use `""` for the workspace root.
+    pub async fn walk_files(&self, rel_path: &str) -> StoreResult<Vec<String>> {
+        let mut result = Vec::new();
+        let mut dirs: Vec<String> = vec![rel_path.to_string()];
+
+        while let Some(dir) = dirs.pop() {
+            let dir_fs = if dir.is_empty() {
+                self.data_dir.clone()
+            } else {
+                self.full_path(&dir)
+            };
+
+            let mut reader = fs::read_dir(&dir_fs).await.map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    StoreError::NotFound { path: dir.clone() }
+                } else {
+                    StoreError::Io(e)
+                }
+            })?;
+
+            while let Some(dirent) = reader.next_entry().await.map_err(StoreError::Io)? {
+                let file_type = dirent.file_type().await.map_err(StoreError::Io)?;
+                let name = dirent.file_name().to_string_lossy().into_owned();
+                let child = if dir.is_empty() {
+                    name.clone()
+                } else {
+                    format!("{}/{}", dir.trim_end_matches('/'), name)
+                };
+                if file_type.is_dir() {
+                    dirs.push(child);
+                } else if file_type.is_file() && name.ends_with(".md") {
+                    result.push(child);
+                }
+            }
+        }
+
+        result.sort();
+        Ok(result)
+    }
+
     /// Renames/moves an entry within this Store's data directory.
     pub async fn rename_entry(&self, from_rel: &str, to_rel: &str) -> StoreResult<()> {
         let src = self.full_path(from_rel);

--- a/modules/wrazz-frontend/src/components/FileTree.tsx
+++ b/modules/wrazz-frontend/src/components/FileTree.tsx
@@ -1,6 +1,18 @@
 import { useState, useEffect, useRef } from "react";
 import { Entry, createFile, createDir, moveEntry, deleteEntry, listEntries } from "../api/files";
-import { ChevronRight, ChevronDown, FilePlus, FolderPlus, Trash2 } from "../icons";
+import { ChevronRight, ChevronDown, Download, FilePlus, FolderPlus, Trash2 } from "../icons";
+
+function pathToUrl(path: string): string {
+  return path.replace(/^\/|\/$/g, "");
+}
+
+function triggerDownload(url: string) {
+  const a = document.createElement("a");
+  a.href = url;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
 import ContextMenu, { ContextMenuItem } from "./ContextMenu";
 import ConfirmModal from "./modals/ConfirmModal";
 
@@ -239,6 +251,7 @@ export default function FileTree({ activePath, onOpen, onDeleted, reloadKey, wid
   function fileCtxItems(path: string): ContextMenuItem[] {
     return [
       { label: "Rename", onClick: () => startEdit(path) },
+      { label: "Export", onClick: () => triggerDownload(`/api/export/file/${pathToUrl(path)}`) },
       { label: "Delete", danger: true, onClick: () => doDelete(path) },
     ];
   }
@@ -248,6 +261,7 @@ export default function FileTree({ activePath, onOpen, onDeleted, reloadKey, wid
       { label: "New File", onClick: () => doNewFile(path) },
       { label: "New Folder", onClick: () => doNewDir(path) },
       { label: "Rename", onClick: () => startEdit(path) },
+      { label: "Export as zip", onClick: () => triggerDownload(`/api/export/dir/${pathToUrl(path)}`) },
       { label: "Delete", danger: true, onClick: () => doDelete(path) },
     ];
   }
@@ -374,6 +388,9 @@ export default function FileTree({ activePath, onOpen, onDeleted, reloadKey, wid
           </button>
           <button className="btn-icon" onClick={() => doNewDir("/")} aria-label="New folder">
             <FolderPlus />
+          </button>
+          <button className="btn-icon" onClick={() => triggerDownload("/api/export/dir")} aria-label="Export workspace">
+            <Download />
           </button>
         </div>
       </div>

--- a/modules/wrazz-frontend/src/icons/index.tsx
+++ b/modules/wrazz-frontend/src/icons/index.tsx
@@ -61,6 +61,16 @@ export function FolderPlus({ size = 16, ...props }: IconProps) {
   );
 }
 
+export function Download({ size = 16, ...props }: IconProps) {
+  return (
+    <svg {...defaults(size)} {...props}>
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" x2="12" y1="15" y2="3" />
+    </svg>
+  );
+}
+
 export function Trash2({ size = 16, ...props }: IconProps) {
   return (
     <svg {...defaults(size)} {...props}>

--- a/modules/wrazz-server/Cargo.toml
+++ b/modules/wrazz-server/Cargo.toml
@@ -32,3 +32,6 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "uuid", 
 argon2 = "0.5"
 openidconnect = { version = "3", features = ["reqwest"] }
 reqwest = { workspace = true }
+async_zip = { version = "0.0.17", features = ["deflate", "tokio"] }
+tokio-util = { version = "0.7", features = ["io", "compat"] }
+futures-util = "0.3"

--- a/modules/wrazz-server/src/routes/export.rs
+++ b/modules/wrazz-server/src/routes/export.rs
@@ -1,0 +1,140 @@
+//! Export endpoints — authenticated, scoped to the requesting user's workspace.
+//!
+//! - `GET /api/export/file/{*path}` — download a single file as `text/markdown`
+//! - `GET /api/export/dir/{*path}`  — download a directory subtree as a zip
+//! - `GET /api/export/dir`          — download the entire workspace as a zip
+
+use async_zip::{Compression, ZipEntryBuilder};
+use async_zip::tokio::write::ZipFileWriter;
+use axum::{
+    body::Body,
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use futures_util::io::AsyncWriteExt;
+use axum::http::header;
+use tokio_util::compat::TokioAsyncWriteCompatExt;
+use tokio_util::io::ReaderStream;
+use uuid::Uuid;
+use wrazz_backend::StoreError;
+
+use super::auth::AuthUser;
+use crate::state::AppState;
+
+// --- Error type ---
+
+pub(crate) struct ApiError(StoreError);
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let status = match &self.0 {
+            StoreError::NotFound { .. } => StatusCode::NOT_FOUND,
+            StoreError::Conflict { .. } => StatusCode::CONFLICT,
+            StoreError::Io(_) | StoreError::Parse { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        (status, self.0.to_string()).into_response()
+    }
+}
+
+impl From<StoreError> for ApiError {
+    fn from(e: StoreError) -> Self { Self(e) }
+}
+
+impl From<std::io::Error> for ApiError {
+    fn from(e: std::io::Error) -> Self { Self(StoreError::Io(e)) }
+}
+
+// --- Handlers ---
+
+pub async fn export_file(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(rel): Path<String>,
+) -> Result<Response, ApiError> {
+    let store = state.store_cache.get_or_create(auth_user.0.id).await?;
+    let bytes = store.read_raw(&rel).await?;
+    let filename = rel.split('/').next_back().unwrap_or(&rel).to_string();
+
+    Ok(Response::builder()
+        .header(header::CONTENT_TYPE, "text/markdown; charset=utf-8")
+        .header(header::CONTENT_DISPOSITION, format!("attachment; filename=\"{filename}\""))
+        .body(Body::from(bytes))
+        .unwrap())
+}
+
+pub async fn export_dir(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(rel): Path<String>,
+) -> Result<Response, ApiError> {
+    build_zip_response(state, auth_user.0.id, &rel).await
+}
+
+pub async fn export_dir_root(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> Result<Response, ApiError> {
+    build_zip_response(state, auth_user.0.id, "").await
+}
+
+async fn build_zip_response(
+    state: AppState,
+    user_id: Uuid,
+    raw_rel: &str,
+) -> Result<Response, ApiError> {
+    let rel_path = raw_rel.trim_matches('/');
+    let store = state.store_cache.get_or_create(user_id).await?;
+
+    let file_paths = store.walk_files(rel_path).await?;
+
+    // Prefix to strip so zip entries are relative to the exported root.
+    let strip_prefix = if rel_path.is_empty() {
+        String::new()
+    } else {
+        format!("{}/", rel_path)
+    };
+
+    let zip_name = if rel_path.is_empty() {
+        "workspace".to_string()
+    } else {
+        rel_path.split('/').next_back().unwrap_or("export").to_string()
+    };
+
+    // Collect raw bytes up front so the Arc<Store> doesn't need to cross the spawn boundary.
+    let mut file_data: Vec<(String, Vec<u8>)> = Vec::with_capacity(file_paths.len());
+    for file_path in &file_paths {
+        let entry_name = if strip_prefix.is_empty() {
+            file_path.clone()
+        } else {
+            file_path.strip_prefix(&strip_prefix).unwrap_or(file_path).to_string()
+        };
+        match store.read_raw(file_path).await {
+            Ok(bytes) => file_data.push((entry_name, bytes)),
+            Err(e) => tracing::warn!("skipping {file_path} during export: {e}"),
+        }
+    }
+
+    // Stream the zip through a tokio duplex channel.
+    // async_zip's tokio module uses futures-style AsyncWrite internally, so the
+    // writer side needs to be compat-wrapped via TokioAsyncWriteCompatExt.
+    let (writer, reader) = tokio::io::duplex(65536);
+    let stream = ReaderStream::new(reader);
+
+    tokio::spawn(async move {
+        let mut zip = ZipFileWriter::new(writer.compat_write());
+        for (entry_name, bytes) in file_data {
+            let entry = ZipEntryBuilder::new(entry_name.into(), Compression::Deflate);
+            let Ok(mut ew) = zip.write_entry_stream(entry).await else { return };
+            if ew.write_all(&bytes).await.is_err() { return; }
+            if ew.close().await.is_err() { return; }
+        }
+        let _ = zip.close().await;
+    });
+
+    Ok(Response::builder()
+        .header(header::CONTENT_TYPE, "application/zip")
+        .header(header::CONTENT_DISPOSITION, format!("attachment; filename=\"{zip_name}.zip\""))
+        .body(Body::from_stream(stream))
+        .unwrap())
+}

--- a/modules/wrazz-server/src/routes/mod.rs
+++ b/modules/wrazz-server/src/routes/mod.rs
@@ -19,6 +19,7 @@
 /// - `POST   /api/dirs`                — create directory
 pub mod admin;
 pub mod auth;
+pub mod export;
 pub mod files;
 pub mod oidc;
 pub mod user;
@@ -63,6 +64,11 @@ pub fn router(state: AppState, static_dir: Option<String>) -> Router {
     let dir_routes = Router::new()
         .route("/dirs/{*path}", post(files::create_dir));
 
+    let export_routes = Router::new()
+        .route("/export/file/{*path}", get(export::export_file))
+        .route("/export/dir", get(export::export_dir_root))
+        .route("/export/dir/{*path}", get(export::export_dir));
+
     let api = Router::new()
         .nest("/auth", auth_routes)
         .merge(user_routes)
@@ -70,7 +76,8 @@ pub fn router(state: AppState, static_dir: Option<String>) -> Router {
         .merge(entry_routes)
         .merge(file_routes)
         .merge(content_routes)
-        .merge(dir_routes);
+        .merge(dir_routes)
+        .merge(export_routes);
 
     let base = Router::new()
         .nest("/api", api)


### PR DESCRIPTION
## Summary

- Adds three authenticated export routes to `wrazz-server`:
  - `GET /api/export/file/{*path}` — single file download as `text/markdown` (raw on-disk format, includes YAML front matter)
  - `GET /api/export/dir/{*path}` — directory subtree as `.zip`
  - `GET /api/export/dir` — entire workspace as `workspace.zip`
- Zip is built with `async-zip` (Deflate) and streamed through a `tokio::io::duplex` channel — response starts flowing before the archive is fully built
- `Store` gains `walk_files` (iterative DFS, no async boxing) and `read_raw` for raw on-disk bytes
- Frontend: "Export" in file context menu, "Export as zip" in dir context menu, Download icon button in sidebar header for one-click workspace export
- Export scope is scoped to the session user's workspace (same auth as all other routes)

## Test plan

- [ ] Right-click a file → Export → browser downloads the `.md` file with YAML front matter intact
- [ ] Right-click a directory → Export as zip → zip contains all `.md` files with paths relative to that directory
- [ ] Click the Download icon in the sidebar header → `workspace.zip` downloads with full file tree
- [ ] Right-click a non-existent path → 404 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)