### PR TITLE
feat: IndexedDB draft persistence, unsaved-changes bar, and Ctrl+S

### DIFF
--- a/modules/wrazz-frontend/src/App.tsx
+++ b/modules/wrazz-frontend/src/App.tsx
@@ -6,6 +6,7 @@ import FileTree from "./components/FileTree";
 import Editor, { Draft } from "./components/Editor";
 import StatusBar from "./components/StatusBar";
 import LoginPage from "./components/LoginPage";
+import { getDraft, saveDraft, clearDraft, getAllDraftPaths } from "./lib/drafts";
 
 // ── Title helpers ──────────────────────────────────────────────────────────
 
@@ -28,7 +29,13 @@ export default function App() {
   const [activePath, setActivePath] = useState<string | null>(null);
   const [activeFile, setActiveFile] = useState<FileEntry | null>(null);
   const [draft, setDraft] = useState<Draft | null>(null);
+  const [isDirty, setIsDirty] = useState(false);
+  const [draftPaths, setDraftPaths] = useState<Set<string>>(new Set());
   const [status, setStatus] = useState<AppStatus | null>(null);
+
+  const activePathRef = useRef<string | null>(null);
+  activePathRef.current = activePath;
+  const persistTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT);
   const dragState = useRef<{ startX: number; startWidth: number } | null>(null);
@@ -59,6 +66,9 @@ export default function App() {
     getCurrentUser()
       .then((u) => setUser(u))
       .finally(() => setAuthChecked(true));
+    getAllDraftPaths()
+      .then((paths) => setDraftPaths(new Set(paths)))
+      .catch(() => {});
   }, []);
 
   function reload() {
@@ -67,17 +77,37 @@ export default function App() {
 
   async function handleOpen(path: string) {
     try {
-      const [file, { content }] = await Promise.all([
+      const [file, { content }, stored] = await Promise.all([
         getFile(path),
         getFileContent(path),
+        getDraft(path),
       ]);
       setActivePath(path);
       setActiveFile(file);
-      setDraft({ title: file.title ?? "", content, tags: file.tags });
+      if (stored) {
+        setDraft({ title: stored.title, content: stored.content, tags: stored.tags });
+        setIsDirty(true);
+      } else {
+        setDraft({ title: file.title ?? "", content, tags: file.tags });
+        setIsDirty(false);
+      }
       setStatus(null);
     } catch {
       setStatus({ kind: "error", message: "Could not load file." });
     }
+  }
+
+  function handleChange(newDraft: Draft) {
+    setDraft(newDraft);
+    setIsDirty(true);
+    if (persistTimer.current) clearTimeout(persistTimer.current);
+    persistTimer.current = setTimeout(() => {
+      const path = activePathRef.current;
+      if (path) {
+        saveDraft(path, newDraft.title, newDraft.content, newDraft.tags).catch(() => {});
+        setDraftPaths((prev) => prev.has(path) ? prev : new Set([...prev, path]));
+      }
+    }, 500);
   }
 
   async function handleSave() {
@@ -85,6 +115,9 @@ export default function App() {
     try {
       const updated = await updateFile(activePath, draft.title.trim() || null, draft.tags, draft.content);
       setActiveFile(updated);
+      await clearDraft(activePath);
+      setIsDirty(false);
+      setDraftPaths((prev) => { const s = new Set(prev); s.delete(activePath); return s; });
       reload();
       setStatus({ kind: "ok", message: "Saved" });
     } catch {
@@ -92,12 +125,21 @@ export default function App() {
     }
   }
 
+  async function handleDiscard() {
+    if (!activePath) return;
+    await clearDraft(activePath);
+    await handleOpen(activePath);
+  }
+
   function handleTreeDeleted(path: string) {
     if (!activePath) return;
     if (activePath === path || activePath.startsWith(path)) {
+      clearDraft(path).catch(() => {});
+      setDraftPaths((prev) => { const s = new Set(prev); s.delete(path); return s; });
       setActivePath(null);
       setActiveFile(null);
       setDraft(null);
+      setIsDirty(false);
     }
   }
 
@@ -107,6 +149,7 @@ export default function App() {
     setActivePath(null);
     setActiveFile(null);
     setDraft(null);
+    setIsDirty(false);
     setStatus(null);
   }
 
@@ -125,14 +168,17 @@ export default function App() {
           onDeleted={handleTreeDeleted}
           reloadKey={reloadKey}
           width={sidebarWidth}
+          draftPaths={draftPaths}
         />
         <div className="sidebar-resizer" onMouseDown={onResizerMouseDown} />
         <Editor
           file={activeFile}
           draft={draft}
           activePath={activePath}
-          onChange={setDraft}
+          isDirty={isDirty}
+          onChange={handleChange}
           onSave={handleSave}
+          onDiscard={handleDiscard}
           user={user}
           onLogout={handleLogout}
           onUserUpdated={setUser}

--- a/modules/wrazz-frontend/src/components/Editor.tsx
+++ b/modules/wrazz-frontend/src/components/Editor.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from "react";
 import { FileEntry } from "../api/files";
 import { CurrentUser } from "../api/auth";
 import { WrazzEditor } from "wrazz-editor";
-import { Save } from "../icons";
+import { Save, RotateCcw } from "../icons";
 import ProfileModal from "./modals/ProfileModal";
 import AdminModal from "./modals/AdminModal";
 import { pathToDisplayTitle } from "../App";
@@ -19,8 +19,10 @@ interface Props {
   file: FileEntry | null;
   draft: Draft | null;
   activePath: string | null;
+  isDirty: boolean;
   onChange: (draft: Draft) => void;
   onSave: () => void;
+  onDiscard: () => void;
   user: CurrentUser;
   onLogout: () => void;
   onUserUpdated: (user: CurrentUser) => void;
@@ -30,8 +32,10 @@ export default function Editor({
   file,
   draft,
   activePath,
+  isDirty,
   onChange,
   onSave,
+  onDiscard,
   user,
   onLogout,
   onUserUpdated,
@@ -44,8 +48,15 @@ export default function Editor({
     setModal(m);
   }
 
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+      e.preventDefault();
+      onSave();
+    }
+  }
+
   return (
-    <main className="editor">
+    <main className="editor" onKeyDown={handleKeyDown}>
       <div className="editor-header">
         <details ref={menuRef} className="user-menu">
           <summary className="user-menu-trigger">{user.display_name}</summary>
@@ -70,6 +81,9 @@ export default function Editor({
         <AdminModal onClose={() => setModal(null)} currentUserId={user.id} />
       )}
 
+      <div className={`editor-unsaved-bar${isDirty && file ? " is-dirty" : ""}`}>
+        {isDirty && file && <span className="editor-unsaved-msg">Unsaved changes</span>}
+      </div>
       {!file || !draft ? (
         <div className="editor-empty">Select a file or create a new one.</div>
       ) : (
@@ -88,6 +102,11 @@ export default function Editor({
             placeholder="Start writing…"
           />
           {/* After WrazzEditor in DOM so tab order is: title → editor → save */}
+          {isDirty && (
+            <button className="btn-icon editor-discard-btn" onClick={onDiscard} aria-label="Discard changes">
+              <RotateCcw size={14} />
+            </button>
+          )}
           <button className="btn-icon editor-save-btn" onClick={onSave} aria-label="Save">
             <Save />
           </button>

--- a/modules/wrazz-frontend/src/components/FileTree.tsx
+++ b/modules/wrazz-frontend/src/components/FileTree.tsx
@@ -22,6 +22,7 @@ interface Props {
   onDeleted: (path: string) => void;
   reloadKey: number;
   width: number;
+  draftPaths: Set<string>;
 }
 
 interface CtxState {
@@ -54,7 +55,7 @@ function sortedEntries(entries: Entry[]): Entry[] {
 
 // ── Component ──────────────────────────────────────────────────────────────
 
-export default function FileTree({ activePath, onOpen, onDeleted, reloadKey, width }: Props) {
+export default function FileTree({ activePath, onOpen, onDeleted, reloadKey, width, draftPaths }: Props) {
   const [root, setRoot] = useState<Entry[]>([]);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [children, setChildren] = useState<Map<string, Entry[]>>(new Map());
@@ -366,6 +367,7 @@ export default function FileTree({ activePath, onOpen, onDeleted, reloadKey, wid
           ) : (
             <>
               <span className="tree-name">{entryName(entry.path)}</span>
+              {draftPaths.has(entry.path) && <span className="tree-draft-dot" />}
               <span className="tree-actions">
                 <button className="btn-icon btn-icon--danger" onClick={(e) => { e.stopPropagation(); doDeleteConfirm(entry.path); }} aria-label="Delete file">
                   <Trash2 size={13} />

--- a/modules/wrazz-frontend/src/icons/index.tsx
+++ b/modules/wrazz-frontend/src/icons/index.tsx
@@ -71,6 +71,15 @@ export function Download({ size = 16, ...props }: IconProps) {
   );
 }
 
+export function RotateCcw({ size = 16, ...props }: IconProps) {
+  return (
+    <svg {...defaults(size)} {...props}>
+      <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+      <path d="M3 3v5h5" />
+    </svg>
+  );
+}
+
 export function Trash2({ size = 16, ...props }: IconProps) {
   return (
     <svg {...defaults(size)} {...props}>

--- a/modules/wrazz-frontend/src/index.css
+++ b/modules/wrazz-frontend/src/index.css
@@ -193,6 +193,18 @@ body {
   text-overflow: ellipsis;
 }
 
+.tree-draft-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--border-strong);
+  flex-shrink: 0;
+}
+
+.tree-row:hover .tree-draft-dot {
+  display: none;
+}
+
 /* Inline row actions: hidden until the row is hovered */
 .tree-actions {
   display: none;
@@ -252,6 +264,58 @@ body {
   overflow-y: auto;
 }
 
+/* ── Unsaved-changes bar ──────────────────────────────────────── */
+
+/* Always occupies 12px so opening/closing it causes no layout shift.
+   The 12px is half of the reduction from editor-title-row's padding-top (32→8). */
+.editor-unsaved-bar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 12px;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+/* Stripe layer — hidden until .is-dirty, fades top→bottom */
+.editor-unsaved-bar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 6px,
+    color-mix(in srgb, var(--paper-sidebar), var(--paper-topbar) 35%) 6px,
+    color-mix(in srgb, var(--paper-sidebar), var(--paper-topbar) 35%) 12px
+  );
+  mask-image: linear-gradient(to bottom, black 0%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 100%);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.editor-unsaved-bar.is-dirty::before {
+  opacity: 1;
+}
+
+/* Text centered — wide horizontal padding feeds the radial halo,
+   sharp stop keeps the edges crisp rather than bleeding into the stripes */
+.editor-unsaved-msg {
+  position: relative;
+  z-index: 1;
+  font-size: 9px;
+  font-family: ui-monospace, monospace;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--border);
+  padding: 0 36px;
+  background: radial-gradient(ellipse at center, var(--paper) 58%, transparent 66%);
+}
+
 .editor-empty {
   flex: 1;
   display: flex;
@@ -270,9 +334,15 @@ body {
   position: relative;
 }
 
+.editor-discard-btn {
+  position: absolute;
+  top: 20px;
+  right: 44px;
+}
+
 .editor-save-btn {
   position: absolute;
-  top: 32px;
+  top: 20px;
   right: 16px;
 }
 
@@ -281,7 +351,7 @@ body {
 .editor-title-row {
   display: flex;
   align-items: baseline;
-  padding: 32px 16px 8px calc(var(--we-margin) - 12px);
+  padding: 20px 16px 8px calc(var(--we-margin) - 12px);
   flex-shrink: 0;
 }
 
@@ -294,8 +364,8 @@ body {
   background: transparent;
   outline: none;
   min-width: 0;
-  /* Leave room for the absolutely-positioned save button */
-  padding-right: 40px;
+  /* Leave room for the absolutely-positioned save (+ optional discard) buttons */
+  padding-right: 72px;
 }
 
 .editor-title::placeholder {

--- a/modules/wrazz-frontend/src/lib/drafts.ts
+++ b/modules/wrazz-frontend/src/lib/drafts.ts
@@ -1,0 +1,63 @@
+const DB_NAME = "wrazz-drafts";
+const DB_VERSION = 1;
+const STORE = "drafts";
+
+export interface StoredDraft {
+  path: string;
+  title: string;
+  content: string;
+  tags: string[];
+  savedAt: number;
+}
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openDb(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(STORE, { keyPath: "path" });
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => { dbPromise = null; reject(req.error); };
+  });
+  return dbPromise;
+}
+
+export async function getDraft(path: string): Promise<StoredDraft | undefined> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const req = db.transaction(STORE, "readonly").objectStore(STORE).get(path);
+    req.onsuccess = () => resolve(req.result as StoredDraft | undefined);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function saveDraft(path: string, title: string, content: string, tags: string[]): Promise<void> {
+  const db = await openDb();
+  const entry: StoredDraft = { path, title, content, tags, savedAt: Date.now() };
+  return new Promise((resolve, reject) => {
+    const req = db.transaction(STORE, "readwrite").objectStore(STORE).put(entry);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function getAllDraftPaths(): Promise<string[]> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const req = db.transaction(STORE, "readonly").objectStore(STORE).getAllKeys();
+    req.onsuccess = () => resolve(req.result as string[]);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function clearDraft(path: string): Promise<void> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const req = db.transaction(STORE, "readwrite").objectStore(STORE).delete(path);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}


### PR DESCRIPTION
## Summary

- **IndexedDB draft persistence** (`src/lib/drafts.ts`) — full content snapshots keyed by file path, debounced at 500ms. Drafts survive page reload; on file open the stored draft is restored automatically if one exists.
- **Unsaved-changes bar** — always-visible 12px strip above the editor body (no layout shift). Subtle diagonal stripe pattern and "UNSAVED CHANGES" text appear only when dirty; radial gradient halo keeps the text legible against the tape. Height carved from existing title-row padding.
- **Discard button** — `RotateCcw` icon button next to Save, visible only when dirty. Clears the IDB draft and reloads from server.
- **Draft dot in file tree** — 5px `--border-strong` circle next to file names for any path with a stored IDB draft. Hides on row hover so action buttons have room. Seeded from IDB on mount; kept in sync with save/discard/delete.
- **Ctrl+S / Cmd+S** — save shortcut wired on the editor `<main>` element, works regardless of whether the title input or content area is focused.

## Test plan

- [ ] Edit a file, wait 500ms, reload the page — draft should restore
- [ ] Draft dot appears in file tree; disappears after saving
- [ ] Unsaved-changes bar appears/disappears without any layout shift
- [ ] Discard reverts content to server state and clears the dot
- [ ] Ctrl+S / Cmd+S saves from both title and content focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)