### PR TITLE
feat(frontend): command palette + context-aware action chips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "wrazz-backend"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "wrazz-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "wrazz-server"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "argon2",
  "async-trait",

--- a/modules/wrazz-frontend/src/App.tsx
+++ b/modules/wrazz-frontend/src/App.tsx
@@ -3,10 +3,16 @@ import { FileEntry, getFile, getFileContent, updateFile } from "./api/files";
 import { CurrentUser, getCurrentUser, logout } from "./api/auth";
 import { AppStatus } from "./types";
 import FileTree from "./components/FileTree";
+import type { FileTreeHandle } from "./components/FileTree";
 import Editor, { Draft } from "./components/Editor";
+import CommandBar from "./components/CommandBar";
 import StatusBar from "./components/StatusBar";
 import LoginPage from "./components/LoginPage";
 import { getDraft, saveDraft, clearDraft, getAllDraftPaths } from "./lib/drafts";
+import { ActiveContextCtx } from "./lib/context";
+import type { ActionContext } from "./lib/actions";
+import { registerAction } from "./lib/actions";
+import { Save, RotateCcw, FilePlus, FolderPlus, Download } from "./icons";
 
 // ── Title helpers ──────────────────────────────────────────────────────────
 
@@ -36,6 +42,13 @@ export default function App() {
   const activePathRef = useRef<string | null>(null);
   activePathRef.current = activePath;
   const persistTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [activeCtx, setActiveCtx] = useState<ActionContext | null>(null);
+  const fileTreeRef = useRef<FileTreeHandle>(null);
+
+  // Stable handler refs — updated each render so action closures never go stale
+  const handleSaveRef = useRef<() => void>(() => {});
+  const handleDiscardRef = useRef<() => void>(() => {});
 
   const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT);
   const dragState = useRef<{ startX: number; startWidth: number } | null>(null);
@@ -153,6 +166,75 @@ export default function App() {
     setStatus(null);
   }
 
+  // Keep handler refs current every render
+  handleSaveRef.current = handleSave;
+  handleDiscardRef.current = handleDiscard;
+
+  // Register palette actions once on mount; refs keep handlers fresh
+  useEffect(() => {
+    function triggerDownload(url: string) {
+      const a = document.createElement("a");
+      a.href = url;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    }
+
+    const unregs = [
+      registerAction({
+        id: "core:save",
+        label: "Save",
+        keywords: ["save", "write"],
+        icon: Save,
+        contexts: ["editor"],
+        handler: () => handleSaveRef.current(),
+      }),
+      registerAction({
+        id: "core:discard",
+        label: "Discard changes",
+        keywords: ["discard", "revert", "reset"],
+        icon: RotateCcw,
+        contexts: ["editor"],
+        handler: () => handleDiscardRef.current(),
+      }),
+      registerAction({
+        id: "core:new-file",
+        label: "New file",
+        keywords: ["create", "file", "new"],
+        icon: FilePlus,
+        contexts: ["file-tree"],
+        handler: () => fileTreeRef.current?.newFile(),
+      }),
+      registerAction({
+        id: "core:new-folder",
+        label: "New folder",
+        keywords: ["create", "folder", "directory", "new"],
+        icon: FolderPlus,
+        contexts: ["file-tree"],
+        handler: () => fileTreeRef.current?.newDir(),
+      }),
+      registerAction({
+        id: "core:export-file",
+        label: "Export file",
+        keywords: ["export", "download"],
+        icon: Download,
+        contexts: ["editor"],
+        handler: () => {
+          const p = activePathRef.current;
+          if (p) triggerDownload(`/api/export/file/${p.replace(/^\/|\/$/g, "")}`);
+        },
+      }),
+      registerAction({
+        id: "core:export-workspace",
+        label: "Export workspace",
+        keywords: ["export", "download", "zip", "all"],
+        icon: Download,
+        handler: () => triggerDownload("/api/export/dir"),
+      }),
+    ];
+    return () => unregs.forEach((f) => f());
+  }, []);
+
   if (!authChecked) return null;
 
   if (!user) {
@@ -160,31 +242,42 @@ export default function App() {
   }
 
   return (
-    <div className="app">
-      <div className="workspace">
-        <FileTree
-          activePath={activePath}
-          onOpen={handleOpen}
-          onDeleted={handleTreeDeleted}
-          reloadKey={reloadKey}
-          width={sidebarWidth}
-          draftPaths={draftPaths}
-        />
-        <div className="sidebar-resizer" onMouseDown={onResizerMouseDown} />
-        <Editor
-          file={activeFile}
-          draft={draft}
-          activePath={activePath}
-          isDirty={isDirty}
-          onChange={handleChange}
-          onSave={handleSave}
-          onDiscard={handleDiscard}
-          user={user}
-          onLogout={handleLogout}
-          onUserUpdated={setUser}
-        />
+    <ActiveContextCtx.Provider value={{ ctx: activeCtx, setCtx: setActiveCtx }}>
+      <div className="app">
+        <div className="workspace">
+          <FileTree
+            ref={fileTreeRef}
+            activePath={activePath}
+            onOpen={handleOpen}
+            onDeleted={handleTreeDeleted}
+            reloadKey={reloadKey}
+            width={sidebarWidth}
+            draftPaths={draftPaths}
+          />
+          <div className="sidebar-resizer" onMouseDown={onResizerMouseDown} />
+          <div className="editor-column">
+            <CommandBar
+              user={user}
+              onLogout={handleLogout}
+              onUserUpdated={setUser}
+              onOpenFile={handleOpen}
+              reloadKey={reloadKey}
+              hasActiveFile={activeFile !== null}
+              isDirty={isDirty}
+              editorTitle={draft?.title || (activePath ? pathToDisplayTitle(activePath) : null)}
+            />
+            <Editor
+              file={activeFile}
+              draft={draft}
+              activePath={activePath}
+              isDirty={isDirty}
+              onChange={handleChange}
+              onSave={handleSave}
+            />
+          </div>
+        </div>
+        <StatusBar title={draft?.title || (activePath ? pathToDisplayTitle(activePath) : null)} status={status} />
       </div>
-      <StatusBar title={draft?.title || (activePath ? pathToDisplayTitle(activePath) : null)} status={status} />
-    </div>
+    </ActiveContextCtx.Provider>
   );
 }

--- a/modules/wrazz-frontend/src/components/CommandBar.tsx
+++ b/modules/wrazz-frontend/src/components/CommandBar.tsx
@@ -1,0 +1,332 @@
+import { useRef, useState, useEffect, useMemo } from "react";
+import { CurrentUser } from "../api/auth";
+import { listEntries } from "../api/files";
+import { useActiveContext } from "../lib/context";
+import { getActions } from "../lib/actions";
+import type { Action } from "../lib/actions";
+import { Search } from "../icons";
+import { pathToDisplayTitle } from "../App";
+import ProfileModal from "./modals/ProfileModal";
+import AdminModal from "./modals/AdminModal";
+
+// ── Fuzzy match ────────────────────────────────────────────────────────────
+
+function fuzzyMatch(haystack: string, needle: string): boolean {
+  if (!needle) return true;
+  const h = haystack.toLowerCase();
+  const n = needle.toLowerCase();
+  let hi = 0;
+  for (const c of n) {
+    const idx = h.indexOf(c, hi);
+    if (idx === -1) return false;
+    hi = idx + 1;
+  }
+  return true;
+}
+
+async function listAllFilePaths(path: string): Promise<string[]> {
+  const entries = await listEntries(path).catch(() => []);
+  const paths: string[] = [];
+  await Promise.all(
+    entries.map(async (e) => {
+      if (e.kind === "file") {
+        paths.push(e.path);
+      } else {
+        paths.push(...(await listAllFilePaths(e.path)));
+      }
+    }),
+  );
+  return paths;
+}
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+type Modal = "profile" | "admin" | null;
+
+type PaletteItem =
+  | { kind: "action"; action: Action }
+  | { kind: "file"; path: string; displayLabel: string };
+
+interface Section {
+  label: string | null;
+  items: PaletteItem[];
+}
+
+interface DropdownPos {
+  top: number;
+  left: number;
+  width: number;
+}
+
+interface Props {
+  user: CurrentUser;
+  onLogout: () => void;
+  onUserUpdated: (user: CurrentUser) => void;
+  onOpenFile: (path: string) => void;
+  reloadKey: number;
+  hasActiveFile: boolean;
+  isDirty: boolean;
+  editorTitle: string | null;
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export default function CommandBar({
+  user,
+  onLogout,
+  onUserUpdated,
+  onOpenFile,
+  reloadKey,
+  hasActiveFile,
+  isDirty,
+  editorTitle,
+}: Props) {
+  const menuRef = useRef<HTMLDetailsElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const inputWrapRef = useRef<HTMLDivElement>(null);
+  const commandBarRef = useRef<HTMLDivElement>(null);
+  const [modal, setModal] = useState<Modal>(null);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState(0);
+  const [allFiles, setAllFiles] = useState<string[]>([]);
+  const [dropdownPos, setDropdownPos] = useState<DropdownPos | null>(null);
+
+  const { ctx } = useActiveContext();
+
+  useEffect(() => {
+    listAllFilePaths("/").then(setAllFiles).catch(() => {});
+  }, [reloadKey]);
+
+  function openModal(m: Modal) {
+    if (menuRef.current) menuRef.current.open = false;
+    setModal(m);
+  }
+
+  function openPalette() {
+    if (commandBarRef.current && inputWrapRef.current) {
+      const barRect = commandBarRef.current.getBoundingClientRect();
+      const wrapRect = inputWrapRef.current.getBoundingClientRect();
+      setDropdownPos({ top: barRect.bottom, left: wrapRect.left, width: wrapRect.width });
+    }
+    listAllFilePaths("/").then(setAllFiles).catch(() => {});
+    setOpen(true);
+    setQuery("");
+    setSelected(0);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }
+
+  function closePalette() {
+    setOpen(false);
+    setQuery("");
+    setSelected(0);
+    inputRef.current?.blur();
+  }
+
+  // Ctrl+Shift+P / Cmd+Shift+P global shortcut
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "p") {
+        e.preventDefault();
+        if (open) closePalette();
+        else openPalette();
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  // Compute result sections; `open` in deps ensures getActions() is read fresh on each open.
+  // "Relevant now" always shows editor-context actions (when a file is open), regardless of
+  // which pane currently has focus.
+  const sections = useMemo((): Section[] => {
+    if (!open) return [];
+    const actions = getActions();
+
+    if (!query) {
+      const editorActions = hasActiveFile
+        ? actions.filter((a) => a.contexts?.includes("editor"))
+        : [];
+      const otherActions = actions.filter((a) => !hasActiveFile || !a.contexts?.includes("editor"));
+      const result: Section[] = [];
+      if (editorActions.length > 0) {
+        result.push({ label: "Relevant now", items: editorActions.map((a) => ({ kind: "action", action: a })) });
+      }
+      if (otherActions.length > 0) {
+        result.push({ label: null, items: otherActions.map((a) => ({ kind: "action", action: a })) });
+      }
+      return result;
+    }
+
+    const matchAction = (a: Action) =>
+      fuzzyMatch(a.label, query) || a.keywords?.some((k) => fuzzyMatch(k, query));
+
+    const matched = actions.filter(matchAction);
+    // In search results, still use active pane context for relevance ranking
+    const ctxActions = matched.filter((a) => ctx && a.contexts?.includes(ctx));
+    const otherActions = matched.filter((a) => !ctx || !a.contexts?.includes(ctx));
+
+    const matchedFiles = allFiles
+      .filter((p) => fuzzyMatch(p, query) || fuzzyMatch(pathToDisplayTitle(p), query))
+      .slice(0, 8);
+
+    const result: Section[] = [];
+    if (ctxActions.length + otherActions.length > 0) {
+      result.push({
+        label: "Actions",
+        items: [...ctxActions, ...otherActions].map((a) => ({ kind: "action", action: a })),
+      });
+    }
+    if (matchedFiles.length > 0) {
+      result.push({
+        label: "Files",
+        items: matchedFiles.map((p) => ({ kind: "file", path: p, displayLabel: pathToDisplayTitle(p) })),
+      });
+    }
+    return result;
+  }, [open, query, ctx, allFiles, hasActiveFile]);
+
+  const flatItems = useMemo(() => sections.flatMap((s) => s.items), [sections]);
+
+  const itemIndex = useMemo(() => {
+    const m = new Map<PaletteItem, number>();
+    flatItems.forEach((item, i) => m.set(item, i));
+    return m;
+  }, [flatItems]);
+
+  useEffect(() => { setSelected(0); }, [flatItems]);
+
+  function handleInputKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") { e.preventDefault(); closePalette(); return; }
+    if (e.key === "ArrowDown") { e.preventDefault(); setSelected((s) => Math.min(s + 1, flatItems.length - 1)); return; }
+    if (e.key === "ArrowUp") { e.preventDefault(); setSelected((s) => Math.max(s - 1, 0)); return; }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const item = flatItems[selected];
+      if (!item) return;
+      if (item.kind === "action") { item.action.handler(); closePalette(); }
+      else { onOpenFile(item.path); closePalette(); }
+    }
+  }
+
+  // Always show editor-context action chips when a file is open;
+  // Discard only appears when there are unsaved changes.
+  const contextChips = !hasActiveFile ? [] :
+    getActions()
+      .filter((a) => a.contexts?.includes("editor") && (a.id !== "core:discard" || isDirty))
+      .slice(0, 4);
+
+  return (
+    <>
+      <div className={`command-bar${open ? " is-open" : ""}`} ref={commandBarRef}>
+        {/* Input wrap — acts as the visual bar; chips live inside on the right */}
+        <div className={`command-input-wrap${open ? " is-open" : ""}`} ref={inputWrapRef}>
+          <Search size={14} className="command-input-search-icon" />
+          <input
+            ref={inputRef}
+            className={`command-input${open ? " is-open" : ""}`}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onFocus={() => { if (!open) openPalette(); }}
+            onKeyDown={handleInputKeyDown}
+            placeholder={open ? "Search or run a command…" : (editorTitle || "Search or run a command…")}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          {!open && contextChips.length > 0 && (
+            <div className="command-chips">
+              {contextChips.map((a) => (
+                <button
+                  key={a.id}
+                  className="command-chip"
+                  onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); a.handler(); }}
+                  title={a.label}
+                >
+                  {a.icon && <a.icon size={12} />}
+                  <span>{a.label}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* User menu on the right */}
+        <details ref={menuRef} className="user-menu">
+          <summary className="user-menu-trigger">{user.display_name}</summary>
+          <div className="user-menu-dropdown">
+            <button onClick={() => openModal("profile")}>Profile</button>
+            {user.is_admin && (
+              <button onClick={() => openModal("admin")}>Administration</button>
+            )}
+            <div className="user-menu-divider" />
+            <button onClick={onLogout}>Sign out</button>
+          </div>
+        </details>
+      </div>
+
+      {/* Transparent backdrop — captures clicks outside to close */}
+      {open && <div className="command-backdrop" onMouseDown={closePalette} />}
+
+      {/* Dropdown positioned below the input bar */}
+      {open && dropdownPos && (
+        <div
+          className="command-dropdown"
+          style={{ top: dropdownPos.top, left: dropdownPos.left, width: dropdownPos.width }}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          {flatItems.length === 0 ? (
+            <div className="palette-empty">No results</div>
+          ) : (
+            sections.map((section, si) => (
+              <div key={si}>
+                {si > 0 && <div className="palette-separator" />}
+                {section.label && <div className="palette-section-label">{section.label}</div>}
+                {section.items.map((item) => {
+                  const idx = itemIndex.get(item) ?? 0;
+                  const isSel = idx === selected;
+                  if (item.kind === "action") {
+                    return (
+                      <button
+                        key={item.action.id}
+                        className={`palette-result${isSel ? " is-selected" : ""}`}
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={() => { item.action.handler(); closePalette(); }}
+                        onMouseEnter={() => setSelected(idx)}
+                      >
+                        {item.action.icon && <item.action.icon size={14} />}
+                        <span className="palette-result-label">{item.action.label}</span>
+                      </button>
+                    );
+                  }
+                  return (
+                    <button
+                      key={item.path}
+                      className={`palette-result${isSel ? " is-selected" : ""}`}
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => { onOpenFile(item.path); closePalette(); }}
+                      onMouseEnter={() => setSelected(idx)}
+                    >
+                      <span className="palette-result-label">{item.displayLabel}</span>
+                      <span className="palette-result-path">{item.path}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+
+      {modal === "profile" && (
+        <ProfileModal
+          user={user}
+          onClose={() => setModal(null)}
+          onUpdated={(u) => { onUserUpdated(u); }}
+        />
+      )}
+      {modal === "admin" && (
+        <AdminModal onClose={() => setModal(null)} currentUserId={user.id} />
+      )}
+    </>
+  );
+}

--- a/modules/wrazz-frontend/src/components/Editor.tsx
+++ b/modules/wrazz-frontend/src/components/Editor.tsx
@@ -1,10 +1,6 @@
-import { useRef, useState } from "react";
 import { FileEntry } from "../api/files";
-import { CurrentUser } from "../api/auth";
 import { WrazzEditor } from "wrazz-editor";
-import { Save, RotateCcw } from "../icons";
-import ProfileModal from "./modals/ProfileModal";
-import AdminModal from "./modals/AdminModal";
+import { useActiveContext } from "../lib/context";
 import { pathToDisplayTitle } from "../App";
 
 export interface Draft {
@@ -13,8 +9,6 @@ export interface Draft {
   tags: string[];
 }
 
-type Modal = "profile" | "admin" | null;
-
 interface Props {
   file: FileEntry | null;
   draft: Draft | null;
@@ -22,10 +16,6 @@ interface Props {
   isDirty: boolean;
   onChange: (draft: Draft) => void;
   onSave: () => void;
-  onDiscard: () => void;
-  user: CurrentUser;
-  onLogout: () => void;
-  onUserUpdated: (user: CurrentUser) => void;
 }
 
 export default function Editor({
@@ -35,18 +25,8 @@ export default function Editor({
   isDirty,
   onChange,
   onSave,
-  onDiscard,
-  user,
-  onLogout,
-  onUserUpdated,
 }: Props) {
-  const menuRef = useRef<HTMLDetailsElement>(null);
-  const [modal, setModal] = useState<Modal>(null);
-
-  function openModal(m: Modal) {
-    if (menuRef.current) menuRef.current.open = false;
-    setModal(m);
-  }
+  const { setCtx } = useActiveContext();
 
   function handleKeyDown(e: React.KeyboardEvent) {
     if ((e.metaKey || e.ctrlKey) && e.key === "s") {
@@ -56,30 +36,7 @@ export default function Editor({
   }
 
   return (
-    <main className="editor" onKeyDown={handleKeyDown}>
-      <div className="editor-header">
-        <details ref={menuRef} className="user-menu">
-          <summary className="user-menu-trigger">{user.display_name}</summary>
-          <div className="user-menu-dropdown">
-            <button onClick={() => openModal("profile")}>Profile</button>
-            {user.is_admin && (
-              <button onClick={() => openModal("admin")}>Administration</button>
-            )}
-            <div className="user-menu-divider" />
-            <button onClick={onLogout}>Sign out</button>
-          </div>
-        </details>
-      </div>
-      {modal === "profile" && (
-        <ProfileModal
-          user={user}
-          onClose={() => setModal(null)}
-          onUpdated={(u) => { onUserUpdated(u); }}
-        />
-      )}
-      {modal === "admin" && (
-        <AdminModal onClose={() => setModal(null)} currentUserId={user.id} />
-      )}
+    <main className="editor" onKeyDown={handleKeyDown} onClick={() => setCtx("editor")}>
 
       <div className={`editor-unsaved-bar${isDirty && file ? " is-dirty" : ""}`}>
         {isDirty && file && <span className="editor-unsaved-msg">Unsaved changes</span>}
@@ -101,15 +58,6 @@ export default function Editor({
             onChange={(content) => onChange({ ...draft, content })}
             placeholder="Start writing…"
           />
-          {/* After WrazzEditor in DOM so tab order is: title → editor → save */}
-          {isDirty && (
-            <button className="btn-icon editor-discard-btn" onClick={onDiscard} aria-label="Discard changes">
-              <RotateCcw size={14} />
-            </button>
-          )}
-          <button className="btn-icon editor-save-btn" onClick={onSave} aria-label="Save">
-            <Save />
-          </button>
         </div>
       )}
     </main>

--- a/modules/wrazz-frontend/src/components/FileTree.tsx
+++ b/modules/wrazz-frontend/src/components/FileTree.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, forwardRef, useImperativeHandle } from "react";
 import { Entry, createFile, createDir, moveEntry, deleteEntry, listEntries } from "../api/files";
-import { ChevronRight, ChevronDown, Download, FilePlus, FolderPlus, Trash2 } from "../icons";
+import { ChevronRight, ChevronDown, Download, FilePlus, FolderPlus, Trash2, Menu } from "../icons";
+import { useActiveContext } from "../lib/context";
 
 function pathToUrl(path: string): string {
   return path.replace(/^\/|\/$/g, "");
@@ -15,6 +16,11 @@ function triggerDownload(url: string) {
 }
 import ContextMenu, { ContextMenuItem } from "./ContextMenu";
 import ConfirmModal from "./modals/ConfirmModal";
+
+export interface FileTreeHandle {
+  newFile: (parentPath?: string) => void;
+  newDir: (parentPath?: string) => void;
+}
 
 interface Props {
   activePath: string | null;
@@ -55,7 +61,10 @@ function sortedEntries(entries: Entry[]): Entry[] {
 
 // ── Component ──────────────────────────────────────────────────────────────
 
-export default function FileTree({ activePath, onOpen, onDeleted, reloadKey, width, draftPaths }: Props) {
+const FileTree = forwardRef<FileTreeHandle, Props>(function FileTree(
+  { activePath, onOpen, onDeleted, reloadKey, width, draftPaths },
+  ref,
+) {
   const [root, setRoot] = useState<Entry[]>([]);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [children, setChildren] = useState<Map<string, Entry[]>>(new Map());
@@ -65,10 +74,18 @@ export default function FileTree({ activePath, onOpen, onDeleted, reloadKey, wid
   const [dragOverPath, setDragOverPath] = useState<string | null>(null);
   const [ctx, setCtx] = useState<CtxState | null>(null);
   const [confirmPath, setConfirmPath] = useState<string | null>(null);
+  const [wsMenuOpen, setWsMenuOpen] = useState(false);
 
   const editInputRef = useRef<HTMLInputElement>(null);
   const expandedRef = useRef(expanded);
   expandedRef.current = expanded;
+
+  const { setCtx: setActivePane } = useActiveContext();
+
+  useImperativeHandle(ref, () => ({
+    newFile: (parentPath = "/") => doNewFile(parentPath),
+    newDir: (parentPath = "/") => doNewDir(parentPath),
+  }));
 
   useEffect(() => {
     const input = editInputRef.current;
@@ -381,19 +398,34 @@ export default function FileTree({ activePath, onOpen, onDeleted, reloadKey, wid
   }
 
   return (
-    <aside className="sidebar" style={{ width }}>
+    <aside className="sidebar" style={{ width }} onClick={() => setActivePane("file-tree")}>
       <div className="sidebar-header">
-        <span className="sidebar-heading">Files</span>
-        <div className="sidebar-header-actions">
-          <button className="btn-icon" onClick={() => doNewFile("/")} aria-label="New file">
-            <FilePlus />
+        <span className="sidebar-heading">Workspace</span>
+        <div className="sidebar-menu">
+          <button
+            className="sidebar-menu-btn"
+            onClick={() => setWsMenuOpen((o) => !o)}
+            aria-label="Workspace menu"
+          >
+            <Menu size={14} />
           </button>
-          <button className="btn-icon" onClick={() => doNewDir("/")} aria-label="New folder">
-            <FolderPlus />
-          </button>
-          <button className="btn-icon" onClick={() => triggerDownload("/api/export/dir")} aria-label="Export workspace">
-            <Download />
-          </button>
+          {wsMenuOpen && (
+            <>
+              <div className="sidebar-menu-backdrop" onMouseDown={() => setWsMenuOpen(false)} />
+              <div className="sidebar-menu-dropdown">
+                <button className="sidebar-menu-item" onClick={() => { doNewFile("/"); setWsMenuOpen(false); }}>
+                  <FilePlus size={13} /> New file
+                </button>
+                <button className="sidebar-menu-item" onClick={() => { doNewDir("/"); setWsMenuOpen(false); }}>
+                  <FolderPlus size={13} /> New folder
+                </button>
+                <hr className="sidebar-menu-divider" />
+                <button className="sidebar-menu-item" onClick={() => { triggerDownload("/api/export/dir"); setWsMenuOpen(false); }}>
+                  <Download size={13} /> Export workspace
+                </button>
+              </div>
+            </>
+          )}
         </div>
       </div>
       <div
@@ -433,4 +465,6 @@ export default function FileTree({ activePath, onOpen, onDeleted, reloadKey, wid
       )}
     </aside>
   );
-}
+});
+
+export default FileTree;

--- a/modules/wrazz-frontend/src/icons/index.tsx
+++ b/modules/wrazz-frontend/src/icons/index.tsx
@@ -91,3 +91,22 @@ export function Trash2({ size = 16, ...props }: IconProps) {
     </svg>
   );
 }
+
+export function Search({ size = 16, ...props }: IconProps) {
+  return (
+    <svg {...defaults(size)} {...props}>
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  );
+}
+
+export function Menu({ size = 16, ...props }: IconProps) {
+  return (
+    <svg {...defaults(size)} {...props}>
+      <line x1="4" y1="6" x2="20" y2="6" />
+      <line x1="4" y1="12" x2="20" y2="12" />
+      <line x1="4" y1="18" x2="20" y2="18" />
+    </svg>
+  );
+}

--- a/modules/wrazz-frontend/src/index.css
+++ b/modules/wrazz-frontend/src/index.css
@@ -49,11 +49,11 @@ body {
   overflow: hidden;
 }
 
-/* ── Shared top-bar style (sidebar-header + editor-header) ───── */
+/* ── Shared top-bar style (sidebar-header + command-bar) ─────── */
 
 .sidebar-header,
-.editor-header {
-  height: 40px;
+.command-bar {
+  height: 60px;
   padding: 0 14px;
   background: var(--paper-topbar);
   border-bottom: 1px solid var(--border-strong);
@@ -65,20 +65,95 @@ body {
 .sidebar-header {
   position: relative;
   justify-content: space-between;
+  padding: 0 8px 0 18px;
 }
 
 /* The resizer element acts as the full-height divider; no pseudo-element needed. */
 
-.editor-header {
-  justify-content: flex-end;
+.command-bar {
+  gap: 8px;
 }
 
 .sidebar-heading {
-  font-size: 11px;
+  font-size: 12px;
   font-family: ui-monospace, monospace;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
   color: var(--ink-muted);
+}
+
+/* ── Sidebar workspace menu ───────────────────────────────────── */
+
+.sidebar-menu {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.sidebar-menu-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  border-radius: 5px;
+  cursor: pointer;
+  color: var(--ink-muted);
+  padding: 0;
+}
+
+.sidebar-menu-btn:hover {
+  color: var(--ink);
+  border-color: var(--ink-muted);
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.sidebar-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 99;
+}
+
+.sidebar-menu-dropdown {
+  position: absolute;
+  top: calc(100% + 5px);
+  right: 0;
+  z-index: 100;
+  background: var(--paper);
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  min-width: 192px;
+  padding: 3px 0;
+}
+
+.sidebar-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  padding: 7px 12px;
+  font-size: 12px;
+  font-family: ui-monospace, monospace;
+  color: var(--ink-muted);
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.sidebar-menu-item:hover {
+  color: var(--ink);
+  background: rgba(0, 0, 0, 0.04);
+  border-color: transparent;
+}
+
+.sidebar-menu-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 3px 0;
+  border: none;
 }
 
 /* ── Sidebar ──────────────────────────────────────────────────── */
@@ -103,7 +178,7 @@ body {
    * Layered gradients: top layer fills topbar, bottom layer provides body split.
    */
   background:
-    linear-gradient(to bottom, var(--paper-topbar) 40px, transparent 40px),
+    linear-gradient(to bottom, var(--paper-topbar) 60px, transparent 60px),
     linear-gradient(to right, var(--paper-sidebar) 50%, var(--paper) 50%);
 }
 
@@ -119,8 +194,8 @@ body {
   transform: translateX(-50%);
   background: linear-gradient(
     to bottom,
-    var(--border-strong) 40px,
-    var(--border) 40px
+    var(--border-strong) 60px,
+    var(--border) 60px
   );
   transition: background 0.1s;
 }
@@ -136,7 +211,7 @@ body {
   position: absolute;
   left: 0;
   right: 0;
-  top: 39px;
+  top: 59px;
   height: 1px;
   background: var(--border-strong);
 }
@@ -257,11 +332,202 @@ body {
 
 /* ── Editor column ────────────────────────────────────────────── */
 
+.editor-column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+
 .editor {
   flex: 1;
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+}
+
+/* ── Command bar input ────────────────────────────────────────── */
+
+/* When open, raise above the backdrop so the input stays clickable */
+.command-bar.is-open {
+  position: relative;
+  z-index: 202;
+}
+
+/* Input wrap acts as the visual "bar" — border lives here, not on the input */
+.command-input-wrap {
+  flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  height: 40px;
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  transition: border-color 0.1s;
+}
+
+.command-input-wrap.is-open {
+  border-color: var(--ink-muted);
+}
+
+.command-input-search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--ink-muted);
+  pointer-events: none;
+  display: flex;
+  flex-shrink: 0;
+}
+
+.command-input {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: 0 10px 0 36px;
+  font-size: 13px;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  color: var(--ink);
+  text-align: center;
+  cursor: pointer;
+}
+
+.command-input::placeholder {
+  color: var(--ink-muted);
+}
+
+.command-input.is-open {
+  text-align: left;
+  cursor: text;
+  padding-right: 10px;
+}
+
+/* Context chips inside the input wrap, to the right of the text */
+.command-chips {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  padding-right: 8px;
+}
+
+.command-chip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 28px;
+  padding: 0 8px;
+  font-size: 11px;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  color: var(--ink-muted);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.command-chip:hover {
+  color: var(--ink);
+  border-color: var(--ink-muted);
+  background: rgba(0, 0, 0, 0.04);
+}
+
+/* ── Command dropdown ─────────────────────────────────────────── */
+
+/* Transparent full-screen backdrop — captures outside clicks to close */
+.command-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+}
+
+/* Dropdown anchored below the input bar via JS-computed position */
+.command-dropdown {
+  position: fixed;
+  z-index: 203; /* must exceed .command-bar.is-open (202) */
+  background: var(--paper);
+  border: 1px solid var(--border-strong);
+  border-top: none;
+  border-radius: 0 0 8px 8px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
+  overflow-y: auto;
+  max-height: 360px;
+  padding: 4px 0;
+}
+
+.palette-section-label {
+  font-size: 10px;
+  font-family: ui-monospace, monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  padding: 6px 16px 3px;
+  user-select: none;
+}
+
+.palette-separator {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
+.palette-result {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  padding: 7px 16px;
+  cursor: pointer;
+  font-size: 13px;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  color: var(--ink-muted);
+  min-width: 0;
+}
+
+.palette-result:hover,
+.palette-result.is-selected {
+  color: var(--ink);
+  background: rgba(0, 0, 0, 0.04);
+  border-color: transparent;
+}
+
+.palette-result-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.palette-result-path {
+  font-size: 11px;
+  font-family: ui-monospace, monospace;
+  color: var(--ink-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 0;
+  max-width: 40%;
+}
+
+.palette-empty {
+  padding: 20px 16px;
+  font-size: 13px;
+  font-family: ui-monospace, monospace;
+  color: var(--ink-muted);
+  text-align: center;
 }
 
 /* ── Unsaved-changes bar ──────────────────────────────────────── */
@@ -334,18 +600,6 @@ body {
   position: relative;
 }
 
-.editor-discard-btn {
-  position: absolute;
-  top: 20px;
-  right: 44px;
-}
-
-.editor-save-btn {
-  position: absolute;
-  top: 20px;
-  right: 16px;
-}
-
 /* ── Title row ────────────────────────────────────────────────── */
 
 .editor-title-row {
@@ -364,8 +618,6 @@ body {
   background: transparent;
   outline: none;
   min-width: 0;
-  /* Leave room for the absolutely-positioned save (+ optional discard) buttons */
-  padding-right: 72px;
 }
 
 .editor-title::placeholder {
@@ -452,7 +704,8 @@ body {
   font-size: 11px;
   font-family: ui-monospace, monospace;
   color: var(--ink-muted);
-  padding: 3px 10px;
+  height: 30px;
+  padding: 5px 10px;
   border: 1px solid var(--border-strong);
   border-radius: 3px;
   user-select: none;

--- a/modules/wrazz-frontend/src/lib/actions.ts
+++ b/modules/wrazz-frontend/src/lib/actions.ts
@@ -1,0 +1,26 @@
+import type { ComponentType } from "react";
+
+export type ActionContext = "editor" | "file-tree";
+
+export interface Action {
+  id: string;
+  label: string;
+  keywords?: string[];
+  icon?: ComponentType<{ size?: number }>;
+  contexts?: ActionContext[];
+  handler: () => void;
+}
+
+const registry: Action[] = [];
+
+export function registerAction(action: Action): () => void {
+  registry.push(action);
+  return () => {
+    const i = registry.indexOf(action);
+    if (i !== -1) registry.splice(i, 1);
+  };
+}
+
+export function getActions(): readonly Action[] {
+  return registry;
+}

--- a/modules/wrazz-frontend/src/lib/context.ts
+++ b/modules/wrazz-frontend/src/lib/context.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from "react";
+import type { ActionContext } from "./actions";
+
+interface ActiveContextValue {
+  ctx: ActionContext | null;
+  setCtx: (c: ActionContext | null) => void;
+}
+
+export const ActiveContextCtx = createContext<ActiveContextValue>({
+  ctx: null,
+  setCtx: () => {},
+});
+
+export function useActiveContext() {
+  return useContext(ActiveContextCtx);
+}


### PR DESCRIPTION
## Summary

- Adds a new `CommandBar` component: an always-visible search/command input bar sitting above the editor. Chips for context-sensitive actions (Save, Export file, etc.) appear inside the bar on the right when a file is open; the bar expands into a filtered dropdown on focus.
- Adds `lib/actions.ts` (module-level action registry) and `lib/context.ts` (active-pane React context) to power the palette.
- `FileTree` gains a `forwardRef`/`useImperativeHandle` API (`newFile`, `newDir`) and replaces its three action buttons with a hamburger dropdown under a "Workspace" heading.
- `Editor` drops its standalone save/discard header buttons (Ctrl+S shortcut kept); `App` registers 6 palette actions with stable handler refs so closures never go stale.
- Also includes the Cargo.lock update for the 0.1.5 version bump from the previous commit.

Closes #23.

## Test plan

- [ ] Open a file — Save and Export file chips appear inside the command bar
- [ ] Dirty a file — Discard changes chip appears alongside Save
- [ ] Close file — chips disappear
- [ ] Click/focus command bar — dropdown opens below the input, width matches the input area (not the user menu)
- [ ] Type to filter — actions and file results fuzzy-match correctly; Enter runs selected item
- [ ] Ctrl+Shift+P toggles palette open/close
- [ ] Workspace hamburger menu: New file, New folder, Export workspace all work
- [ ] Sidebar resizer visual line aligns with the top bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)